### PR TITLE
Improve test by verifying that the header value had been set correctly

### DIFF
--- a/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
+++ b/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
@@ -83,6 +83,7 @@ namespace CorrelationId.Tests
         public async Task CorrelationId_SetToCorrelationIdFromRequestHeader()
         {
             var expectedHeaderName = new CorrelationIdOptions().Header;
+            var expectedHeaderValue = "123456";
 
             var builder = new WebHostBuilder()
                .Configure(app => app.UseCorrelationId());
@@ -90,13 +91,13 @@ namespace CorrelationId.Tests
             var server = new TestServer(builder);
 
             var request = new HttpRequestMessage();
-            request.Headers.Add(expectedHeaderName, "123456");
+            request.Headers.Add(expectedHeaderName, expectedHeaderValue);
 
             var response = await server.CreateClient().SendAsync(request);
                         
             var header = response.Headers.GetValues(expectedHeaderName);
 
-            Assert.NotNull(header);
+            Assert.Single(header, expectedHeaderValue);
         }
     }
 }


### PR DESCRIPTION
The current test simply checks if the header exists (or at least contains any value).
By using `Assert.Single` we can verify that a specific value is actually present in the specified header-