### PR TITLE
Check if response header exists before trying to add it

### DIFF
--- a/src/CorrelationId/CorrelationIdMiddleware.cs
+++ b/src/CorrelationId/CorrelationIdMiddleware.cs
@@ -18,14 +18,8 @@ namespace CorrelationId
         /// <param name="options">The configuration options.</param>
         public CorrelationIdMiddleware(RequestDelegate next, IOptions<CorrelationIdOptions> options)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
             _next = next ?? throw new ArgumentNullException(nameof(next));
-
-            _options = options.Value;
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
 
         /// <summary>
@@ -45,7 +39,11 @@ namespace CorrelationId
                 // apply the correlation ID to the response header for client side tracking
                 context.Response.OnStarting(() =>
                 {
-                    context.Response.Headers.Add(_options.Header, new[] { context.TraceIdentifier });
+                    if (!context.Response.Headers.ContainsKey(_options.Header))
+                    {
+                        context.Response.Headers.Add(_options.Header, new[] { context.TraceIdentifier });
+                    }
+                   
                     return Task.CompletedTask;
                 });
             }


### PR DESCRIPTION
This bug could be experienced in two main example cases.

1. The registration of UseCorrelationId within Startup.Configure is made after the ASP.NET Core exception middleware which re-executes the request pipeline (i.e. UseExceptionHandler). In that case, if the CorrelationIdMiddleware is run twice it will register two delegates with Response.OnStarting which both try to add the correlation ID header to the response (assuming IncludeInResponse is true).

2. A header already exists on the response from somewhere else in the client application with the same name as the Correlation ID middleware is trying to set. By default this is X-Correlation-ID.

Therefore it makes sense to avoid the risk of exceptions by checking first that the header does not exist before trying to add it to the response.

Fixes #3