### PR TITLE
Adding two new configuration options

### DIFF
--- a/samples/MvcCorrelationIdSample/Controllers/ValuesController.cs
+++ b/samples/MvcCorrelationIdSample/Controllers/ValuesController.cs
@@ -32,7 +32,8 @@ namespace MvcCorrelationIdSample.Controllers
                 $"DirectAccessor={correlation}",
                 $"Transient={_transient.GetCorrelationFromScoped}",
                 $"Scoped={_scoped.GetCorrelationFromScoped}",
-                $"Singleton={_singleton.GetCorrelationFromScoped}"
+                $"Singleton={_singleton.GetCorrelationFromScoped}",
+                $"TraceIdentifier={HttpContext.TraceIdentifier}"
             };
         }
     }

--- a/src/CorrelationId/CorrelationContextAccessor.cs
+++ b/src/CorrelationId/CorrelationContextAccessor.cs
@@ -7,6 +7,7 @@ namespace CorrelationId
     {
         private static AsyncLocal<CorrelationContext> _correlationContext = new AsyncLocal<CorrelationContext>();
 
+        /// <inheritdoc />
         public CorrelationContext CorrelationContext
         {
             get => _correlationContext.Value;

--- a/src/CorrelationId/CorrelationId.csproj
+++ b/src/CorrelationId/CorrelationId.csproj
@@ -11,10 +11,18 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>aspnetcore;correlationid</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <DocumentationFile>bin\Release\netstandard1.4\CorrelationId.xml</DocumentationFile>
     <PackageProjectUrl>https://github.com/stevejgordon/CorrelationId</PackageProjectUrl>
     <RepositoryUrl>https://github.com/stevejgordon/CorrelationId</RepositoryUrl>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CorrelationId/CorrelationIdOptions.cs
+++ b/src/CorrelationId/CorrelationIdOptions.cs
@@ -13,8 +13,28 @@
         public string Header { get; set; } = DefaultHeader;
 
         /// <summary>
+        /// <para>
         /// Controls whether the correlation ID is returned in the response headers.
+        /// </para>
+        /// <para>Default: true</para>
         /// </summary>
         public bool IncludeInResponse { get; set; } = true;
+
+        /// <summary>
+        /// <para>
+        /// Controls whether the ASP.NET Core TraceIdentifier will be set to match the CorrelationId.
+        /// </para>
+        /// <para>Default: true</para>
+        /// </summary>
+        public bool UpdateTraceIdentifier { get; set; } = true;
+
+        /// <summary>
+        /// <para>
+        /// Controls whether a GUID will be used in cases where no correlation ID is retrieved from the request header.
+        /// When false the TraceIdentifier for the current request will be used.
+        /// </para>
+        /// <para> Default: false.</para>
+        /// </summary>
+        public bool UseGuidForCorrelationId { get; set; } = false;
     }
 }

--- a/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
+++ b/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
+using System;
 
 namespace CorrelationId.Tests
 {
@@ -52,7 +53,7 @@ namespace CorrelationId.Tests
         }
 
         [Fact]
-        public async Task DoesNotReturnCorrelationIdInResponseHeader_WhenOptionSetToFalse()
+        public async Task DoesNotReturnCorrelationIdInResponseHeader_WhenIncludeInResponseIsFalse()
         {
             var options = new CorrelationIdOptions { IncludeInResponse = false };
 
@@ -70,7 +71,7 @@ namespace CorrelationId.Tests
         }
 
         [Fact]
-        public async Task CorrelationIdHeaderFieldName_MatchesOptions()
+        public async Task CorrelationIdHeaderFieldName_MatchesHeaderOption()
         {
             const string customHeader = "X-Test-Header";
 
@@ -90,7 +91,7 @@ namespace CorrelationId.Tests
         }
 
         [Fact]
-        public async Task CorrelationIdHeaderFieldName_MatchesStringOverload()
+        public async Task CorrelationIdHeaderFieldName_MatchesHeaderFromStringOverload()
         {
             const string customHeader = "X-Test-Header";
 
@@ -127,6 +128,46 @@ namespace CorrelationId.Tests
             var header = response.Headers.GetValues(expectedHeaderName);
 
             Assert.Single(header, expectedHeaderValue);
+        }
+
+        [Fact]
+        public async Task CorrelationId_SetToGuid_WhenUseGuidForCorrelationId_IsTrue()
+        {
+            var options = new CorrelationIdOptions { UseGuidForCorrelationId = true };
+
+            var builder = new WebHostBuilder()
+                .Configure(app => app.UseCorrelationId(options))
+                .ConfigureServices(sc => sc.AddCorrelationId());
+
+            var server = new TestServer(builder);
+            
+            var response = await server.CreateClient().GetAsync("");
+
+            var header = response.Headers.GetValues(new CorrelationIdOptions().Header);
+
+            var isGuid = Guid.TryParse(header.FirstOrDefault(), out _);
+
+            Assert.True(isGuid);
+        }
+
+        [Fact]
+        public async Task CorrelationId_NotSetToGuid_WhenUseGuidForCorrelationId_IsFalse()
+        {
+            var options = new CorrelationIdOptions { UseGuidForCorrelationId = false };
+
+            var builder = new WebHostBuilder()
+                .Configure(app => app.UseCorrelationId(options))
+                .ConfigureServices(sc => sc.AddCorrelationId());
+
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync("");
+
+            var header = response.Headers.GetValues(new CorrelationIdOptions().Header);
+
+            var isGuid = Guid.TryParse(header.FirstOrDefault(), out _);
+
+            Assert.False(isGuid);
         }
 
         [Fact]
@@ -265,6 +306,72 @@ namespace CorrelationId.Tests
             var body = await response.Content.ReadAsStringAsync();
 
             Assert.Equal(body, options.Header);
+        }
+
+        [Fact]
+        public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsFalse()
+        {
+            var options = new CorrelationIdOptions { UpdateTraceIdentifier = false };
+
+            var expectedHeaderName = new CorrelationIdOptions().Header;
+            const string expectedHeaderValue = "123456";
+            
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCorrelationId(options);
+
+                    app.Use(async (ctx, next) =>
+                    {
+                        await ctx.Response.WriteAsync(ctx.TraceIdentifier);
+                        await next();
+                    });
+                })
+                .ConfigureServices(sc => sc.AddCorrelationId());
+
+            var server = new TestServer(builder);
+
+            var request = new HttpRequestMessage();
+            request.Headers.Add(expectedHeaderName, expectedHeaderValue);
+
+            var response = await server.CreateClient().SendAsync(request);
+            
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.NotEqual(body, expectedHeaderValue);
+        }
+
+        [Fact]
+        public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsTrue()
+        {
+            var options = new CorrelationIdOptions { UpdateTraceIdentifier = true };
+
+            var expectedHeaderName = new CorrelationIdOptions().Header;
+            const string expectedHeaderValue = "123456";
+
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCorrelationId(options);
+
+                    app.Use(async (ctx, next) =>
+                    {
+                        await ctx.Response.WriteAsync(ctx.TraceIdentifier);
+                        await next();
+                    });
+                })
+                .ConfigureServices(sc => sc.AddCorrelationId());
+
+            var server = new TestServer(builder);
+
+            var request = new HttpRequestMessage();
+            request.Headers.Add(expectedHeaderName, expectedHeaderValue);
+
+            var response = await server.CreateClient().SendAsync(request);
+
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(body, expectedHeaderValue);
         }
 
         private class SingletonClass


### PR DESCRIPTION
1. Option which determines whether the TraceIdentifier or a Guid is used for the CorrelationId when an ID is not present on the request header.

2. Option which determines whether the TraceIdentifier is updated to match the CorrelationId

Fixes #13