### PR TITLE
Return ServiceCollection instead of void to allow chaining

### DIFF
--- a/src/CorrelationId/CorrelationIdServiceExtensions.cs
+++ b/src/CorrelationId/CorrelationIdServiceExtensions.cs
@@ -12,10 +12,12 @@ namespace CorrelationId
         /// Adds required services to support the Correlation ID functionality.
         /// </summary>
         /// <param name="serviceCollection"></param>
-        public static void AddCorrelationId(this IServiceCollection serviceCollection)
+        public static IServiceCollection AddCorrelationId(this IServiceCollection serviceCollection)
         {
             serviceCollection.TryAddSingleton<ICorrelationContextAccessor, CorrelationContextAccessor>();
             serviceCollection.TryAddTransient<ICorrelationContextFactory, CorrelationContextFactory>();
+
+            return serviceCollection;
         }
     }
 }


### PR DESCRIPTION
It's good practice for the extension methods to return the same type they are extending instead of returning `void`, since this allows chaining the calls. 