### PR TITLE
Add intended scopes/transient for registration in unit tests

### DIFF
--- a/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
+++ b/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
@@ -193,7 +193,7 @@ namespace CorrelationId.Tests
                 {
                     sc.AddCorrelationId();
                     sc.TryAddSingleton<SingletonClass>();
-                    sc.TryAddSingleton<ScopedClass>();
+                    sc.TryAddScoped<ScopedClass>();
                 });
 
             var server = new TestServer(builder);
@@ -247,8 +247,8 @@ namespace CorrelationId.Tests
                 .ConfigureServices(sc =>
                 {
                     sc.AddCorrelationId();
-                    sc.TryAddSingleton<TransientClass>();
-                    sc.TryAddSingleton<ScopedClass>();
+                    sc.TryAddTransient<TransientClass>();
+                    sc.TryAddScoped<ScopedClass>();
                 });
 
             var server = new TestServer(builder);


### PR DESCRIPTION
I think the unit tests intended to make these scoped and transient.