### PR TITLE
adds correlation id to log context

### DIFF
--- a/src/CorrelationId/CorrelationId.csproj
+++ b/src/CorrelationId/CorrelationId.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Just wanted to propose this as a POC before taking it further...

What you're doing here is very similar to something I'm doing as well, but yours is better.  If you can't beat 'em, join em!

The only thing missing from what I'd like is for the correlation id to be added to the log context to easily group log entries in structured log aggregators.

Requires an additional dependency on Microsoft.Extensions.Logging.Abstractions but it's a pretty safe bet that's not an issue since this is intended for use with AspNetCore.

Thoughts?