### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Examples in the [wiki](https://github.com/stevejgordon/CorrelationId/wiki).
 
 ## Known Issue with ASP.NET Core 2.2.0
 
-It appears that a [regression in the code for ASP.NET Core 2.2.0](https://github.com/aspnet/AspNetCore/issues/5144) means that setting the TraceIdentifier on the context via middleware results in the context becoming null when accessed further down in the pipeline. A fix is ready for 3.0.0 and te team plan to back-port this for the 2.2.2 release timeframe
+It appears that a [regression in the code for ASP.NET Core 2.2.0](https://github.com/aspnet/AspNetCore/issues/5144) means that setting the TraceIdentifier on the context via middleware results in the context becoming null when accessed further down in the pipeline. A fix is ready for 3.0.0 and the team plan to back-port this for the 2.2.2 release timeframe.
 
 A workaround at this time is to disable the behaviour of updating the TraceIdentifier using the options when adding the middleware...
 


### PR DESCRIPTION
Hey Steve,

I was taking a look at this library and noticed a small typo in the Readme. I wasn't sure what branch to link this to, GitHub defaulted to dev so I left it as that. 

Let me know if this isn't right and I will change the PR.

Nick