### PR TITLE
Return serviceCollection to allow chained calls

### DIFF
--- a/src/CorrelationId/CorrelationIdServiceExtensions.cs
+++ b/src/CorrelationId/CorrelationIdServiceExtensions.cs
@@ -12,10 +12,12 @@ namespace CorrelationId
         /// Adds required services to support the Correlation ID functionality.
         /// </summary>
         /// <param name="serviceCollection"></param>
-        public static void AddCorrelationId(this IServiceCollection serviceCollection)
+        public static IServiceCollection AddCorrelationId(this IServiceCollection serviceCollection)
         {
             serviceCollection.TryAddSingleton<ICorrelationContextAccessor, CorrelationContextAccessor>();
             serviceCollection.TryAddTransient<ICorrelationContextFactory, CorrelationContextFactory>();
+
+            return serviceCollection;
         }
     }
 }


### PR DESCRIPTION
This proposed change enables use of the original IServiceCollection supplied to AddCorrelationId() to be re-used in order to support chaining eg. services.AddCorrelationId().AddNextThingToServiceCollection().....etc