### PR TITLE
NET 6.0 Upgrade, Log Level Severity option + improvements

### DIFF
--- a/CorrelationId.sln
+++ b/CorrelationId.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorrelationId", "src\CorrelationId\CorrelationId.csproj", "{865886FC-EBBE-49E1-8F49-FECD0408EF6E}"
 EndProject
@@ -26,11 +26,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{5961B376
 		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3.1", "3.1", "{E28C5481-A68F-44AF-983F-EA127E70621A}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "6.0", "6.0", "{E28C5481-A68F-44AF-983F-EA127E70621A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvcSample", "samples\3.1\MvcSample\MvcSample.csproj", "{9393676B-BE08-44C9-B556-7BE31CFA5B86}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvcSampleTests", "samples\6.0\MvcSampleTests\MvcSampleTests.csproj", "{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvcSampleTests", "samples\3.1\MvcSampleTests\MvcSampleTests.csproj", "{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MvcSample", "samples\6.0\MvcSample\MvcSample.csproj", "{C7BC8C49-7D3C-4CFE-AE13-CA56CA6B01A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -46,14 +46,14 @@ Global
 		{41035337-9829-4A6A-8EA9-42CC94734CE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41035337-9829-4A6A-8EA9-42CC94734CE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41035337-9829-4A6A-8EA9-42CC94734CE6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9393676B-BE08-44C9-B556-7BE31CFA5B86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9393676B-BE08-44C9-B556-7BE31CFA5B86}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9393676B-BE08-44C9-B556-7BE31CFA5B86}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9393676B-BE08-44C9-B556-7BE31CFA5B86}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7BC8C49-7D3C-4CFE-AE13-CA56CA6B01A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7BC8C49-7D3C-4CFE-AE13-CA56CA6B01A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7BC8C49-7D3C-4CFE-AE13-CA56CA6B01A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7BC8C49-7D3C-4CFE-AE13-CA56CA6B01A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -62,8 +62,8 @@ Global
 		{865886FC-EBBE-49E1-8F49-FECD0408EF6E} = {9A14C73A-D8FC-40C3-81FC-D0687F43FEAF}
 		{41035337-9829-4A6A-8EA9-42CC94734CE6} = {EAF27B74-0B27-4BEE-9F82-DD5812B21B17}
 		{E28C5481-A68F-44AF-983F-EA127E70621A} = {34C0F65A-8BF2-40DA-B0E7-844930EE2A7B}
-		{9393676B-BE08-44C9-B556-7BE31CFA5B86} = {E28C5481-A68F-44AF-983F-EA127E70621A}
 		{0E2E2678-4DBB-4560-AF0E-86ECAF8D9B6F} = {E28C5481-A68F-44AF-983F-EA127E70621A}
+		{C7BC8C49-7D3C-4CFE-AE13-CA56CA6B01A5} = {E28C5481-A68F-44AF-983F-EA127E70621A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C0A37404-C50B-472E-9491-DDE2A4BDA882}

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -2,6 +2,37 @@
 
 Packages are available on NuGet: [CorrelationId](https://www.nuget.org/packages/CorrelationId/).
 
+## v4.0.0
+
+### .NET 6 Upgrade
+
+* All components are fully upgraded to .NET 6.0, including the sample.
+
+### Configuration Options
+
+* Added a new option to set log level severity when a correlation ID is found in the header or a correlation ID is missing from the header. 
+
+```
+    options.CorrelationIdGenerator = () => "Foo";
+    options.AddToLoggingScope = true;
+    options.EnforceHeader = false; //set true to enforce the correlation ID
+    options.IgnoreRequestHeader = false;
+    options.IncludeInResponse = true;
+    options.RequestHeader = "My-Custom-Correlation-Id";
+    options.ResponseHeader = "X-Correlation-Id";
+    options.UpdateTraceIdentifier = false;
+    **
+    options.LogLevelOptions = new CorrelationIdLogLevelOptions
+    {
+        //set log level severity
+        FoundCorrelationIdHeader = LogLevel.Debug,  
+        MissingCorrelationIdHeader = LogLevel.Debug
+    };
+    **
+```
+
+## v3.0.0
+
 ## v3.0.1
 
 ### Bug Fixes

--- a/samples/6.0/MvcSample/Controllers/WeatherForecastController.cs
+++ b/samples/6.0/MvcSample/Controllers/WeatherForecastController.cs
@@ -1,0 +1,47 @@
+﻿using CorrelationId.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MvcSample.Controllers;
+
+[ApiController]
+[Route("weather-forecast")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] _summaries =
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ICorrelationContextAccessor _contextAccessor;
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger,
+        IHttpClientFactory httpClientFactory, ICorrelationContextAccessor contextAccessor)
+    {
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+        _contextAccessor = contextAccessor;
+    }
+
+    [HttpGet]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        _logger.LogInformation("CorrelationId: {CorrelationId}", _contextAccessor.CorrelationContext.CorrelationId);
+
+        var client =
+            _httpClientFactory.CreateClient("MyClient"); // this client will attach the correlation ID header
+
+        client.GetAsync("https://www.example.com");
+
+        var rng = new Random();
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = _summaries[rng.Next(_summaries.Length)]
+            })
+            .ToArray();
+    }
+}

--- a/samples/6.0/MvcSample/DoNothingCorrelationIdProvider.cs
+++ b/samples/6.0/MvcSample/DoNothingCorrelationIdProvider.cs
@@ -4,7 +4,7 @@ namespace MvcSample;
 
 public class DoNothingCorrelationIdProvider : ICorrelationIdProvider
 {
-    public string GenerateCorrelationId(HttpContext context)
+    public string GenerateCorrelationId()
     {
         return null;
     }

--- a/samples/6.0/MvcSample/DoNothingCorrelationIdProvider.cs
+++ b/samples/6.0/MvcSample/DoNothingCorrelationIdProvider.cs
@@ -1,0 +1,11 @@
+using CorrelationId.Abstractions;
+
+namespace MvcSample;
+
+public class DoNothingCorrelationIdProvider : ICorrelationIdProvider
+{
+    public string GenerateCorrelationId(HttpContext context)
+    {
+        return null;
+    }
+}

--- a/samples/6.0/MvcSample/MvcSample.csproj
+++ b/samples/6.0/MvcSample/MvcSample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\src\CorrelationId\CorrelationId.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/samples/6.0/MvcSample/NoOpDelegatingHandler.cs
+++ b/samples/6.0/MvcSample/NoOpDelegatingHandler.cs
@@ -1,0 +1,27 @@
+﻿using System.Net;
+
+namespace MvcSample;
+
+public class NoOpDelegatingHandler : DelegatingHandler
+{
+    private readonly ILogger<NoOpDelegatingHandler> _logger;
+
+    public NoOpDelegatingHandler(ILogger<NoOpDelegatingHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Headers.TryGetValues("X-Correlation-Id", out var headerEnumerable))
+            _logger.LogInformation("Request has the following correlation ID header {CorrelationId}.",
+                headerEnumerable.FirstOrDefault());
+        else
+            _logger.LogInformation("Request does not have a correlation ID header.");
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+        return Task.FromResult(response);
+    }
+}

--- a/samples/6.0/MvcSample/Program.cs
+++ b/samples/6.0/MvcSample/Program.cs
@@ -1,0 +1,63 @@
+﻿using CorrelationId;
+using CorrelationId.DependencyInjection;
+using CorrelationId.HttpClient;
+using MvcSample;
+using NLog;
+using NLog.Extensions.Logging;
+using NLog.Web;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseNLog();
+
+// Add services to the container.
+builder.Services.AddControllers();
+
+builder.Services.AddTransient<NoOpDelegatingHandler>();
+
+builder.Services.AddHttpClient("MyClient")
+    .AddCorrelationIdForwarding() // add the handler to attach the correlation ID to outgoing requests for this named client
+    .AddHttpMessageHandler<NoOpDelegatingHandler>();
+
+// Example of adding default correlation ID (using the GUID generator) services
+// As shown here, options can be configured via the configure delegate overload
+builder.Services.AddDefaultCorrelationId(options =>
+{
+    options.CorrelationIdGenerator = () => "Foo";
+    options.AddToLoggingScope = true;
+    options.EnforceHeader = false; //set true to enforce the correlation ID
+    options.IgnoreRequestHeader = false;
+    options.IncludeInResponse = true;
+    options.RequestHeader = "My-Custom-Correlation-Id";
+    options.ResponseHeader = "X-Correlation-Id";
+    options.UpdateTraceIdentifier = false;
+    options.LogLevelOptions = new CorrelationIdLogLevelOptions
+    {
+        //set log level severity
+        FoundCorrelationIdHeader = LogLevel.Debug,  
+        MissingCorrelationIdHeader = LogLevel.Debug
+    };
+});
+
+// Example of registering a custom correlation ID provider
+//builder.Services.AddCorrelationId().WithCustomProvider<DoNothingCorrelationIdProvider>();
+
+//Setup NLog
+LogManager.Setup().LoadConfigurationFromSection(builder.Configuration);
+
+var app = builder.Build();
+
+app.UseCorrelationId(); // adds the correlation ID middleware
+
+app.UseHttpsRedirection();
+
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/samples/6.0/MvcSample/Program.cs
+++ b/samples/6.0/MvcSample/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddDefaultCorrelationId(options =>
     options.LogLevelOptions = new CorrelationIdLogLevelOptions
     {
         //set log level severity
-        FoundCorrelationIdHeader = LogLevel.Debug,  
+        FoundCorrelationIdHeader = LogLevel.Debug,
         MissingCorrelationIdHeader = LogLevel.Debug
     };
 });

--- a/samples/6.0/MvcSample/Properties/launchSettings.json
+++ b/samples/6.0/MvcSample/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:29386",
+      "sslPort": 44343
+    }
+  },
+  "profiles": {
+    "MvcSample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weather-forecast",
+      "applicationUrl": "https://localhost:7131;http://localhost:5131",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weather-forecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/6.0/MvcSample/ServiceWhichUsesCorrelationContext.cs
+++ b/samples/6.0/MvcSample/ServiceWhichUsesCorrelationContext.cs
@@ -1,0 +1,20 @@
+﻿using CorrelationId.Abstractions;
+
+namespace MvcSample;
+
+public class ServiceWhichUsesCorrelationContext
+{
+    private readonly ICorrelationContextAccessor _correlationContextAccessor;
+
+    public ServiceWhichUsesCorrelationContext(ICorrelationContextAccessor correlationContextAccessor)
+    {
+        _correlationContextAccessor = correlationContextAccessor;
+    }
+
+    public string DoStuff()
+    {
+        var correlationId = _correlationContextAccessor.CorrelationContext.CorrelationId;
+
+        return $"Formatted correlation ID:{correlationId}";
+    }
+}

--- a/samples/6.0/MvcSample/WeatherForecast.cs
+++ b/samples/6.0/MvcSample/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace MvcSample;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string Summary { get; set; }
+}

--- a/samples/6.0/MvcSample/appsettings.Development.json
+++ b/samples/6.0/MvcSample/appsettings.Development.json
@@ -1,0 +1,91 @@
+{
+  "AllowedHosts": "*",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "NLog": {
+      "IncludeScopes": true
+    }
+  },
+  "NLog": {
+    "autoReload": true,
+    "throwConfigExceptions": true,
+    "default-wrapper": {
+      "type": "AsyncWrapper",
+      "overflowAction": "Block"
+    },
+    "targets": {
+      "file": {
+        "type": "File",
+        "fileName": "${basedir}/${shortDate}-MvcSample.log",
+        "archiveFileName": "${basedir}/archive-files/{#####}-MvcSample.log",
+        "archiveEvery": "Day",
+        "archiveAboveSize": "67108864",
+        "archiveNumbering": "DateAndSequence",
+        "maxArchiveFiles": "-1",
+        "concurrentWrites": "false",
+        "keepFileOpen": "true",
+        "deleteOldFileOnStartup": "false",
+        "createDirs": "true",
+        "layout": {
+          "type": "JsonLayout",
+          "includeAllProperties": "true",
+          "maxRecursionLimit": "10",
+          "Attributes": [
+            {
+              "name": "time",
+              "layout": "${longDate}"
+            },
+            {
+              "name": "level",
+              "layout": "${level:upperCase=true}"
+            },
+            {
+              "name": "source",
+              "layout": "${callsite}"
+            },
+            {
+              "name": "message",
+              "layout": "${message}"
+            },
+            {
+              "name": "exception",
+              "layout": "${exception:format=toString}"
+            }
+          ]
+        }
+      },
+      "console": {
+        "type": "LimitingWrapper",
+        "interval": "00:00:01",
+        "messageLimit": 100,
+        "target": {
+          "type": "ColoredConsole",
+          "layout":
+            "${longDate}|${event-properties:item=EventId_Id:whenEmpty=0}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}|${callsite}",
+          "rowHighlightingRules": [
+            {
+              "condition": "level == LogLevel.Error",
+              "foregroundColor": "Red"
+            },
+            {
+              "condition": "level == LogLevel.Fatal",
+              "foregroundColor": "Red",
+              "backgroundColor": "White"
+            }
+          ]
+        }
+      }
+    },
+    "rules": [
+      {
+        "logger": "*",
+        "minLevel": "Trace",
+        "writeTo": "file, console"
+      }
+    ]
+  }
+}

--- a/samples/6.0/MvcSample/appsettings.json
+++ b/samples/6.0/MvcSample/appsettings.json
@@ -1,0 +1,92 @@
+{
+  "AllowedHosts": "*",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Warning"
+    },
+    "NLog": {
+      "IncludeScopes": true
+    }
+  },
+  "NLog": {
+    "autoReload": true,
+    "throwConfigExceptions": true,
+    "default-wrapper": {
+      "type": "AsyncWrapper",
+      "overflowAction": "Block"
+    },
+    "targets": {
+      "file": {
+        "type": "File",
+        "fileName": "${basedir}/${shortDate}-MvcSample.log",
+        "archiveFileName": "${basedir}/archive-files/{#####}-MvcSample.log",
+        "archiveEvery": "Day",
+        "archiveAboveSize": "67108864",
+        "archiveNumbering": "DateAndSequence",
+        "maxArchiveFiles": "-1",
+        "concurrentWrites": "false",
+        "keepFileOpen": "true",
+        "deleteOldFileOnStartup": "false",
+        "createDirs": "true",
+        "layout": {
+          "type": "JsonLayout",
+          "includeAllProperties": "true",
+          "maxRecursionLimit": "10",
+          "Attributes": [
+            {
+              "name": "time",
+              "layout": "${longDate}"
+            },
+            {
+              "name": "level",
+              "layout": "${level:upperCase=true}"
+            },
+            {
+              "name": "source",
+              "layout": "${callsite}"
+            },
+            {
+              "name": "message",
+              "layout": "${message}"
+            },
+            {
+              "name": "exception",
+              "layout": "${exception:format=toString}"
+            }
+          ]
+        }
+      },
+      "console": {
+        "type": "LimitingWrapper",
+        "interval": "00:00:01",
+        "messageLimit": 100,
+        "target": {
+          "type": "ColoredConsole",
+          "layout":
+            "${longDate}|${event-properties:item=EventId_Id:whenEmpty=0}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}|${callsite}",
+          "rowHighlightingRules": [
+            {
+              "condition": "level == LogLevel.Error",
+              "foregroundColor": "Red"
+            },
+            {
+              "condition": "level == LogLevel.Fatal",
+              "foregroundColor": "Red",
+              "backgroundColor": "White"
+            }
+          ]
+        }
+      }
+    },
+    "rules": [
+      {
+        "logger": "*",
+        "minLevel": "Trace",
+        "writeTo": "file, console"
+      }
+    ]
+  }
+}

--- a/samples/6.0/MvcSampleTests/MvcSampleTests.csproj
+++ b/samples/6.0/MvcSampleTests/MvcSampleTests.csproj
@@ -1,27 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	  <LangVersion>latest</LangVersion>
-	  <ImplicitUsings>enable</ImplicitUsings>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CorrelationId\CorrelationId.csproj" />
+    <ProjectReference Include="..\MvcSample\MvcSample.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 
 </Project>

--- a/samples/6.0/MvcSampleTests/ServiceWhichUsesCorrelationContextTests.cs
+++ b/samples/6.0/MvcSampleTests/ServiceWhichUsesCorrelationContextTests.cs
@@ -2,6 +2,7 @@ using CorrelationId;
 using CorrelationId.Abstractions;
 using Moq;
 using MvcSample;
+using Xunit;
 
 namespace MvcSampleTests;
 

--- a/samples/6.0/MvcSampleTests/ServiceWhichUsesCorrelationContextTests.cs
+++ b/samples/6.0/MvcSampleTests/ServiceWhichUsesCorrelationContextTests.cs
@@ -1,0 +1,23 @@
+using CorrelationId;
+using CorrelationId.Abstractions;
+using Moq;
+using MvcSample;
+
+namespace MvcSampleTests;
+
+public class ServiceWhichUsesCorrelationContextTests
+{
+    [Fact]
+    public void DoStuff_Test()
+    {
+        var mockCorrelationContextAccessor = new Mock<ICorrelationContextAccessor>();
+        mockCorrelationContextAccessor.Setup(x => x.CorrelationContext)
+            .Returns(new CorrelationContext("ABC", "RequestHeader"));
+
+        var sut = new ServiceWhichUsesCorrelationContext(mockCorrelationContextAccessor.Object);
+
+        var result = sut.DoStuff();
+
+        Assert.Equal("Formatted correlation ID:ABC", result);
+    }
+}

--- a/src/CorrelationId/Abstractions/ICorrelationContextAccessor.cs
+++ b/src/CorrelationId/Abstractions/ICorrelationContextAccessor.cs
@@ -1,13 +1,12 @@
-﻿namespace CorrelationId.Abstractions
+﻿namespace CorrelationId.Abstractions;
+
+/// <summary>
+///     Provides access to the <see cref="CorrelationContext" /> for the current request.
+/// </summary>
+public interface ICorrelationContextAccessor
 {
     /// <summary>
-    /// Provides access to the <see cref="CorrelationContext"/> for the current request.
+    ///     The <see cref="CorrelationContext" /> for the current request.
     /// </summary>
-    public interface ICorrelationContextAccessor
-    {
-        /// <summary>
-        /// The <see cref="CorrelationContext"/> for the current request.
-        /// </summary>
-        CorrelationContext CorrelationContext { get; set; }
-    }
+    CorrelationContext CorrelationContext { get; set; }
 }

--- a/src/CorrelationId/Abstractions/ICorrelationContextFactory.cs
+++ b/src/CorrelationId/Abstractions/ICorrelationContextFactory.cs
@@ -1,21 +1,21 @@
-﻿namespace CorrelationId.Abstractions
+﻿namespace CorrelationId.Abstractions;
+
+/// <summary>
+///     A factory for creating and disposing an instance of a <see cref="CorrelationContext" />.
+/// </summary>
+public interface ICorrelationContextFactory
 {
     /// <summary>
-    /// A factory for creating and disposing an instance of a <see cref="CorrelationContext"/>.
+    ///     Creates a new <see cref="CorrelationContext" /> with the correlation ID set for the current request.
     /// </summary>
-    public interface ICorrelationContextFactory
-    {
-        /// <summary>
-        /// Creates a new <see cref="CorrelationContext"/> with the correlation ID set for the current request.
-        /// </summary>
-        /// <param name="correlationId">The correlation ID to set on the context.</param>
-        /// /// <param name="header">The header used to hold the correlation ID.</param>
-        /// <returns>A new instance of a <see cref="CorrelationContext"/>.</returns>
-        CorrelationContext Create(string correlationId, string header);
+    /// <param name="correlationId">The correlation ID to set on the context.</param>
+    /// ///
+    /// <param name="header">The header used to hold the correlation ID.</param>
+    /// <returns>A new instance of a <see cref="CorrelationContext" />.</returns>
+    CorrelationContext Create(string correlationId, string header);
 
-        /// <summary>
-        /// Disposes of the <see cref="CorrelationContext"/> for the current request.
-        /// </summary>
-        void Dispose();
-    }
+    /// <summary>
+    ///     Disposes of the <see cref="CorrelationContext" /> for the current request.
+    /// </summary>
+    void Dispose();
 }

--- a/src/CorrelationId/Abstractions/ICorrelationIdProvider.cs
+++ b/src/CorrelationId/Abstractions/ICorrelationIdProvider.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-
-namespace CorrelationId.Abstractions;
+﻿namespace CorrelationId.Abstractions;
 
 /// <summary>
 ///     Defines a provider which can be used to generate correlation IDs.
@@ -10,7 +8,6 @@ public interface ICorrelationIdProvider
     /// <summary>
     ///     Generates a correlation ID string for the current request.
     /// </summary>
-    /// <param name="httpContext">The <see cref="HttpContext" /> of the current request.</param>
     /// <returns>A string representing the correlation ID.</returns>
-    string GenerateCorrelationId(HttpContext httpContext);
+    string GenerateCorrelationId();
 }

--- a/src/CorrelationId/Abstractions/ICorrelationIdProvider.cs
+++ b/src/CorrelationId/Abstractions/ICorrelationIdProvider.cs
@@ -1,17 +1,16 @@
 ﻿using Microsoft.AspNetCore.Http;
 
-namespace CorrelationId.Abstractions
+namespace CorrelationId.Abstractions;
+
+/// <summary>
+///     Defines a provider which can be used to generate correlation IDs.
+/// </summary>
+public interface ICorrelationIdProvider
 {
     /// <summary>
-    /// Defines a provider which can be used to generate correlation IDs.
+    ///     Generates a correlation ID string for the current request.
     /// </summary>
-    public interface ICorrelationIdProvider
-    {
-        /// <summary>
-        /// Generates a correlation ID string for the current request.
-        /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> of the current request.</param>
-        /// <returns>A string representing the correlation ID.</returns>
-        string GenerateCorrelationId(HttpContext context);
-    }
+    /// <param name="httpContext">The <see cref="HttpContext" /> of the current request.</param>
+    /// <returns>A string representing the correlation ID.</returns>
+    string GenerateCorrelationId(HttpContext httpContext);
 }

--- a/src/CorrelationId/CorrelationContext.cs
+++ b/src/CorrelationId/CorrelationContext.cs
@@ -1,43 +1,42 @@
 ﻿using CorrelationId.Abstractions;
-using System;
 
-namespace CorrelationId
+namespace CorrelationId;
+
+/// <summary>
+///     Provides access to per request correlation properties.
+/// </summary>
+public class CorrelationContext
 {
     /// <summary>
-    /// Provides access to per request correlation properties.
+    ///     The default correlation ID is used in cases where the correlation has not been set by the
+    ///     <see cref="ICorrelationIdProvider" />.
     /// </summary>
-    public class CorrelationContext
+    public const string DefaultCorrelationId = "Not set";
+
+    /// <summary>
+    ///     Create a <see cref="CorrelationContext" /> instance.
+    /// </summary>
+    /// <param name="correlationId">The correlation ID on the context.</param>
+    /// <param name="header">The name of the header from which the Correlation ID was read/written.</param>
+    /// <exception cref="ArgumentException">Thrown if the <paramref name="header" /> is null or empty.</exception>
+    public CorrelationContext(string correlationId, string header)
     {
-        /// <summary>
-        /// The default correlation ID is used in cases where the correlation has not been set by the <see cref="ICorrelationIdProvider"/>.
-        /// </summary>
-        public const string DefaultCorrelationId = "Not set";
+        correlationId ??= DefaultCorrelationId;
 
-        /// <summary>
-        /// Create a <see cref="CorrelationContext"/> instance.
-        /// </summary>
-        /// <param name="correlationId">The correlation ID on the context.</param>
-        /// <param name="header">The name of the header from which the Correlation ID was read/written.</param>
-        /// <exception cref="ArgumentException">Thrown if the <paramref name="header"/> is null or empty.</exception>
-        public CorrelationContext(string correlationId, string header)
-        {
-            correlationId ??= DefaultCorrelationId;
+        if (string.IsNullOrEmpty(header))
+            throw new ArgumentException("A header must be provided.", nameof(header));
 
-            if (string.IsNullOrEmpty(header))
-                throw new ArgumentException("A header must be provided.", nameof(header));
-
-            CorrelationId = correlationId;
-            Header = header;
-        }
-
-        /// <summary>
-        /// The Correlation ID which is applicable to the current request.
-        /// </summary>
-        public string CorrelationId { get; }
-
-        /// <summary>
-        /// The name of the header from which the Correlation ID was read/written.
-        /// </summary>
-        public string Header { get; }
+        CorrelationId = correlationId;
+        Header = header;
     }
+
+    /// <summary>
+    ///     The Correlation ID which is applicable to the current request.
+    /// </summary>
+    public string CorrelationId { get; }
+
+    /// <summary>
+    ///     The name of the header from which the Correlation ID was read/written.
+    /// </summary>
+    public string Header { get; }
 }

--- a/src/CorrelationId/CorrelationContextAccessor.cs
+++ b/src/CorrelationId/CorrelationContextAccessor.cs
@@ -1,18 +1,16 @@
-﻿using System.Threading;
-using CorrelationId.Abstractions;
+﻿using CorrelationId.Abstractions;
 
-namespace CorrelationId
+namespace CorrelationId;
+
+/// <inheritdoc />
+public class CorrelationContextAccessor : ICorrelationContextAccessor
 {
-    /// <inheritdoc />
-    public class CorrelationContextAccessor : ICorrelationContextAccessor
-    {
-        private static AsyncLocal<CorrelationContext> _correlationContext = new AsyncLocal<CorrelationContext>();
+    private static readonly AsyncLocal<CorrelationContext> _correlationContext = new();
 
-        /// <inheritdoc />
-        public CorrelationContext CorrelationContext
-        {
-            get => _correlationContext.Value;
-            set => _correlationContext.Value = value;
-        }
+    /// <inheritdoc />
+    public CorrelationContext CorrelationContext
+    {
+        get => _correlationContext.Value;
+        set => _correlationContext.Value = value;
     }
 }

--- a/src/CorrelationId/CorrelationContextFactory.cs
+++ b/src/CorrelationId/CorrelationContextFactory.cs
@@ -1,48 +1,45 @@
 ﻿using CorrelationId.Abstractions;
 
-namespace CorrelationId
+namespace CorrelationId;
+
+/// <inheritdoc />
+public class CorrelationContextFactory : ICorrelationContextFactory
 {
-    /// <inheritdoc />
-    public class CorrelationContextFactory : ICorrelationContextFactory
+    private readonly ICorrelationContextAccessor _correlationContextAccessor;
+
+    /// <summary>
+    ///     Initialises a new instance of <see cref="CorrelationContextFactory" />.
+    /// </summary>
+    public CorrelationContextFactory()
+        : this(null)
     {
-        private readonly ICorrelationContextAccessor _correlationContextAccessor;
+    }
 
-        /// <summary>
-        /// Initialises a new instance of <see cref="CorrelationContextFactory" />.
-        /// </summary>
-        public CorrelationContextFactory() 
-            : this(null)
-        { }
+    /// <summary>
+    ///     Initialises a new instance of the <see cref="CorrelationContextFactory" /> class.
+    /// </summary>
+    /// <param name="correlationContextAccessor">
+    ///     The <see cref="ICorrelationContextAccessor" /> through which the
+    ///     <see cref="CorrelationContext" /> will be set.
+    /// </param>
+    public CorrelationContextFactory(ICorrelationContextAccessor correlationContextAccessor)
+    {
+        _correlationContextAccessor = correlationContextAccessor;
+    }
 
-        /// <summary>
-        /// Initialises a new instance of the <see cref="CorrelationContextFactory"/> class.
-        /// </summary>
-        /// <param name="correlationContextAccessor">The <see cref="ICorrelationContextAccessor"/> through which the <see cref="CorrelationContext"/> will be set.</param>
-        public CorrelationContextFactory(ICorrelationContextAccessor correlationContextAccessor)
-        {
-            _correlationContextAccessor = correlationContextAccessor;
-        }
+    /// <inheritdoc />
+    public CorrelationContext Create(string correlationId, string header)
+    {
+        var correlationContext = new CorrelationContext(correlationId, header);
 
-        /// <inheritdoc />
-        public CorrelationContext Create(string correlationId, string header)
-        {
-            var correlationContext = new CorrelationContext(correlationId, header);
+        if (_correlationContextAccessor != null) _correlationContextAccessor.CorrelationContext = correlationContext;
 
-            if (_correlationContextAccessor != null)
-            {
-                _correlationContextAccessor.CorrelationContext = correlationContext;
-            }
+        return correlationContext;
+    }
 
-            return correlationContext;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            if (_correlationContextAccessor != null)
-            {
-                _correlationContextAccessor.CorrelationContext = null;
-            }
-        }
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_correlationContextAccessor != null) _correlationContextAccessor.CorrelationContext = null;
     }
 }

--- a/src/CorrelationId/CorrelationId.csproj
+++ b/src/CorrelationId/CorrelationId.csproj
@@ -1,30 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Steve Gordon</Authors>
-    <Company>Steve Gordon | www.stevejgordon.co.uk</Company>
-    <Product>CorrelationId Middleware for ASP.NET Core</Product>
-    <Description>ASP.NET Core correlation ID middleware for distributed microservices.</Description>
-    <Copyright>© Steve Gordon 2017-2020. All rights reserved.</Copyright>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>aspnetcore;correlationid</PackageTags>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Version>3.0.0</Version>
-    <DocumentationFile>bin\Release\netstandard2.0\CorrelationId.xml</DocumentationFile>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/stevejgordon/CorrelationId</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/stevejgordon/CorrelationId</RepositoryUrl>
-    <LangVersion>8</LangVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+		<Authors>Steve Gordon</Authors>
+		<Company>Steve Gordon | www.stevejgordon.co.uk</Company>
+		<Product>CorrelationId Middleware for ASP.NET Core</Product>
+		<Description>ASP.NET Core correlation ID middleware for distributed microservices.</Description>
+		<Copyright>© Steve Gordon 2017-2020. All rights reserved.</Copyright>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>aspnetcore;correlationid</PackageTags>
+		<NeutralLanguage>en</NeutralLanguage>
+		<Version>3.0.0</Version>
+		<DocumentationFile>bin\Release\netstandard2.0\CorrelationId.xml</DocumentationFile>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/stevejgordon/CorrelationId</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/stevejgordon/CorrelationId</RepositoryUrl>
+		<LangVersion>latest</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+	</ItemGroup>
 
 </Project>

--- a/src/CorrelationId/CorrelationIdExtensions.cs
+++ b/src/CorrelationId/CorrelationIdExtensions.cs
@@ -1,32 +1,26 @@
 ﻿using CorrelationId.Abstractions;
 using Microsoft.AspNetCore.Builder;
-using System;
 
-namespace CorrelationId
+namespace CorrelationId;
+
+/// <summary>
+///     Extension methods for the CorrelationIdMiddleware.
+/// </summary>
+public static class CorrelationIdExtensions
 {
     /// <summary>
-    /// Extension methods for the CorrelationIdMiddleware.
+    ///     Enables correlation IDs for the request.
     /// </summary>
-    public static class CorrelationIdExtensions
+    /// <param name="app"></param>
+    /// <returns></returns>
+    public static IApplicationBuilder UseCorrelationId(this IApplicationBuilder app)
     {
-        /// <summary>
-        /// Enables correlation IDs for the request.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <returns></returns>
-        public static IApplicationBuilder UseCorrelationId(this IApplicationBuilder app)
-        {
-            if (app == null)
-            {
-                throw new ArgumentNullException(nameof(app));
-            }
+        if (app == null) throw new ArgumentNullException(nameof(app));
 
-            if (app.ApplicationServices.GetService(typeof(ICorrelationContextFactory)) == null)
-            {
-                throw new InvalidOperationException("Unable to find the required services. You must call the appropriate AddCorrelationId/AddDefaultCorrelationId method in ConfigureServices in the application startup code.");
-            }
+        if (app.ApplicationServices.GetService(typeof(ICorrelationContextFactory)) == null)
+            throw new InvalidOperationException(
+                "Unable to find the required services. You must call the appropriate AddCorrelationId/AddDefaultCorrelationId method in ConfigureServices in the application startup code.");
 
-            return app.UseMiddleware<CorrelationIdMiddleware>();
-        }
+        return app.UseMiddleware<CorrelationIdMiddleware>();
     }
 }

--- a/src/CorrelationId/CorrelationIdLogLevelOptions.cs
+++ b/src/CorrelationId/CorrelationIdLogLevelOptions.cs
@@ -1,5 +1,4 @@
-﻿using CorrelationId.Abstractions;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace CorrelationId;
 

--- a/src/CorrelationId/CorrelationIdLogLevelOptions.cs
+++ b/src/CorrelationId/CorrelationIdLogLevelOptions.cs
@@ -1,0 +1,26 @@
+﻿using CorrelationId.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace CorrelationId;
+
+/// <summary>
+///     Options for correlation IDs.
+/// </summary>
+public class CorrelationIdLogLevelOptions
+{
+    /// <summary>
+    ///     <para>
+    ///         Defines the log level severity when a correlation Id is found on the header.
+    ///     </para>
+    ///     <para>Default: LogLevel.Information</para>
+    /// </summary>
+    public LogLevel FoundCorrelationIdHeader { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    ///     <para>
+    ///         Defines the log level severity when a correlation Id is missing on the header.
+    ///     </para>
+    ///     <para>Default: LogLevel.Information</para>
+    /// </summary>
+    public LogLevel MissingCorrelationIdHeader { get; set; } = LogLevel.Information;
+}

--- a/src/CorrelationId/CorrelationIdMiddleware.cs
+++ b/src/CorrelationId/CorrelationIdMiddleware.cs
@@ -1,263 +1,249 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using CorrelationId.Abstractions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using CorrelationId.Abstractions;
 
-namespace CorrelationId
+namespace CorrelationId;
+
+/// <summary>
+///     Middleware which attempts to reads / creates a Correlation ID that can then be used in logs and
+///     passed to upstream requests.
+/// </summary>
+public class CorrelationIdMiddleware
 {
-    /// <summary>
-    /// Middleware which attempts to reads / creates a Correlation ID that can then be used in logs and 
-    /// passed to upstream requests.
-    /// </summary>
-    public class CorrelationIdMiddleware
-    {
-        private readonly RequestDelegate _next;
-        private readonly ILogger _logger;
-        private readonly ICorrelationIdProvider _correlationIdProvider;
-        private readonly CorrelationIdOptions _options;
+    private readonly ICorrelationIdProvider _correlationIdProvider;
+    private readonly ILogger _logger;
+    private readonly RequestDelegate _next;
+    private readonly CorrelationIdOptions _options;
 
-        /// <summary>
-        /// Creates a new instance of the CorrelationIdMiddleware.
-        /// </summary>
-        /// <param name="next">The next middleware in the pipeline.</param>
-        /// <param name="logger">The <see cref="ILogger"/> instance to log to.</param>
-        /// <param name="options">The configuration options.</param>
-        /// <param name="correlationIdProvider"></param>
-        public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger, IOptions<CorrelationIdOptions> options, ICorrelationIdProvider correlationIdProvider = null)
+    /// <summary>
+    ///     Creates a new instance of the CorrelationIdMiddleware.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="logger">The <see cref="ILogger" /> instance to log to.</param>
+    /// <param name="options">The configuration options.</param>
+    /// <param name="correlationIdProvider"></param>
+    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger,
+        IOptions<CorrelationIdOptions> options, ICorrelationIdProvider correlationIdProvider = null)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _correlationIdProvider = correlationIdProvider;
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    ///     Processes a request to synchronise TraceIdentifier and Correlation ID headers. Also creates a
+    ///     <see cref="CorrelationContext" /> for the current request and disposes of it when the request is completing.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext" /> for the current request.</param>
+    /// <param name="correlationContextFactory">
+    ///     The <see cref="ICorrelationContextFactory" /> which can create a
+    ///     <see cref="CorrelationContext" />.
+    /// </param>
+    public async Task Invoke(HttpContext httpContext, ICorrelationContextFactory correlationContextFactory)
+    {
+        Log.CorrelationIdProcessingBegin(_logger);
+
+        if (_correlationIdProvider is null)
         {
-            _next = next ?? throw new ArgumentNullException(nameof(next));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _correlationIdProvider = correlationIdProvider;
-            _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+            Log.MissingCorrelationIdProvider(_logger);
+
+            throw new InvalidOperationException(
+                "No 'ICorrelationIdProvider' has been registered. You must either add the correlation ID services" +
+                " using the 'AddDefaultCorrelationId' extension method or you must register a suitable provider using the" +
+                " 'ICorrelationIdBuilder'.");
         }
 
-        /// <summary>
-        /// Processes a request to synchronise TraceIdentifier and Correlation ID headers. Also creates a 
-        /// <see cref="CorrelationContext"/> for the current request and disposes of it when the request is completing.
-        /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
-        /// <param name="correlationContextFactory">The <see cref="ICorrelationContextFactory"/> which can create a <see cref="CorrelationContext"/>.</param>
-        public async Task Invoke(HttpContext context, ICorrelationContextFactory correlationContextFactory)
+        var hasCorrelationIdHeader = httpContext.Request.Headers.TryGetValue(_options.RequestHeader, out var cid) &&
+                                     !StringValues.IsNullOrEmpty(cid);
+
+        if (!hasCorrelationIdHeader && _options.EnforceHeader)
         {
-            Log.CorrelationIdProcessingBegin(_logger);
+            Log.EnforcedCorrelationIdHeaderMissing(_logger);
 
-            if (_correlationIdProvider is null)
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await httpContext.Response.WriteAsync(
+                $"The '{_options.RequestHeader}' request header is required, but was not found.");
+            return;
+        }
+
+        var correlationId = hasCorrelationIdHeader ? cid.FirstOrDefault() : null;
+
+        if (hasCorrelationIdHeader)
+            Log.FoundCorrelationIdHeader(_logger, _options.LogLevelOptions.FoundCorrelationIdHeader, correlationId);
+        else
+            Log.MissingCorrelationIdHeader(_logger, _options.LogLevelOptions.MissingCorrelationIdHeader);
+
+        if (_options.IgnoreRequestHeader || RequiresGenerationOfCorrelationId(hasCorrelationIdHeader, cid))
+            correlationId = GenerateCorrelationId(httpContext);
+
+        if (!string.IsNullOrEmpty(correlationId) && _options.UpdateTraceIdentifier)
+        {
+            Log.UpdatingTraceIdentifier(_logger);
+
+            httpContext.TraceIdentifier = correlationId;
+        }
+
+        Log.CreatingCorrelationContext(_logger);
+        correlationContextFactory.Create(correlationId, _options.RequestHeader);
+
+        if (_options.IncludeInResponse && !string.IsNullOrEmpty(correlationId))
+            // apply the correlation ID to the response header for client side tracking
+            httpContext.Response.OnStarting(() =>
             {
-                Log.MissingCorrelationIdProvider(_logger);
-
-                throw new InvalidOperationException("No 'ICorrelationIdProvider' has been registered. You must either add the correlation ID services" +
-                                                    " using the 'AddDefaultCorrelationId' extension method or you must register a suitable provider using the" +
-                                                    " 'ICorrelationIdBuilder'.");
-            }
-
-            var hasCorrelationIdHeader = context.Request.Headers.TryGetValue(_options.RequestHeader, out var cid) &&
-                                           !StringValues.IsNullOrEmpty(cid);
-
-            if (!hasCorrelationIdHeader && _options.EnforceHeader)
-            {
-                Log.EnforcedCorrelationIdHeaderMissing(_logger);
-
-                context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                await context.Response.WriteAsync($"The '{_options.RequestHeader}' request header is required, but was not found.");
-                return;
-            }
-
-            var correlationId = hasCorrelationIdHeader ? cid.FirstOrDefault() : null;
-
-            if (hasCorrelationIdHeader)
-            {
-                Log.FoundCorrelationIdHeader(_logger, correlationId);
-            }
-            else
-            {
-                Log.MissingCorrelationIdHeader(_logger);
-            }
-
-            if (_options.IgnoreRequestHeader || RequiresGenerationOfCorrelationId(hasCorrelationIdHeader, cid))
-            {
-                correlationId = GenerateCorrelationId(context);
-            }
-
-            if (!string.IsNullOrEmpty(correlationId) && _options.UpdateTraceIdentifier)
-            {
-                Log.UpdatingTraceIdentifier(_logger);
-
-                context.TraceIdentifier = correlationId;
-            }
-
-            Log.CreatingCorrelationContext(_logger);
-            correlationContextFactory.Create(correlationId, _options.RequestHeader);
-
-            if (_options.IncludeInResponse && !string.IsNullOrEmpty(correlationId))
-            {
-                // apply the correlation ID to the response header for client side tracking
-                context.Response.OnStarting(() =>
-                {
-                    if (!context.Response.Headers.ContainsKey(_options.ResponseHeader))
-                    {
-                        Log.WritingCorrelationIdResponseHeader(_logger, _options.ResponseHeader, correlationId);
-                        context.Response.Headers.Add(_options.ResponseHeader, correlationId);
-                    }
-
+                if (httpContext.Response.Headers.ContainsKey(_options.ResponseHeader))
                     return Task.CompletedTask;
-                });
-            }
-            
-            if (_options.AddToLoggingScope && !string.IsNullOrEmpty(_options.LoggingScopeKey) && !string.IsNullOrEmpty(correlationId))
-            {
-                using (_logger.BeginScope(new Dictionary<string, object>
-                {
-                    [_options.LoggingScopeKey] = correlationId
-                }))
-                {
-                    Log.CorrelationIdProcessingEnd(_logger, correlationId);
-                    await _next(context);
-                }
-            }
-            else
+                Log.WritingCorrelationIdResponseHeader(_logger, _options.ResponseHeader, correlationId);
+                httpContext.Response.Headers.Add(_options.ResponseHeader, correlationId);
+
+                return Task.CompletedTask;
+            });
+
+        if (_options.AddToLoggingScope && !string.IsNullOrEmpty(_options.LoggingScopeKey) &&
+            !string.IsNullOrEmpty(correlationId))
+        {
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       [_options.LoggingScopeKey] = correlationId
+                   }))
             {
                 Log.CorrelationIdProcessingEnd(_logger, correlationId);
-                await _next(context);
+                await _next(httpContext);
             }
-
-            Log.DisposingCorrelationContext(_logger);
-            correlationContextFactory.Dispose();
+        }
+        else
+        {
+            Log.CorrelationIdProcessingEnd(_logger, correlationId);
+            await _next(httpContext);
         }
 
-        private static bool RequiresGenerationOfCorrelationId(bool idInHeader, StringValues idFromHeader) =>
-            !idInHeader || StringValues.IsNullOrEmpty(idFromHeader);
+        Log.DisposingCorrelationContext(_logger);
+        correlationContextFactory.Dispose();
+    }
 
-        private string GenerateCorrelationId(HttpContext ctx)
+    private static bool RequiresGenerationOfCorrelationId(bool idInHeader, StringValues idFromHeader)
+    {
+        return !idInHeader || StringValues.IsNullOrEmpty(idFromHeader);
+    }
+
+    private string GenerateCorrelationId(HttpContext ctx)
+    {
+        string correlationId;
+
+        if (_options.CorrelationIdGenerator != null)
         {
-            string correlationId;
-
-            if (_options.CorrelationIdGenerator is object)
-            {
-                correlationId = _options.CorrelationIdGenerator();
-                Log.GeneratedHeaderUsingGeneratorFunction(_logger, correlationId);
-                return correlationId;
-            }
-
-            correlationId = _correlationIdProvider.GenerateCorrelationId(ctx);
-            Log.GeneratedHeaderUsingProvider(_logger, correlationId, _correlationIdProvider.GetType());
+            correlationId = _options.CorrelationIdGenerator();
+            Log.GeneratedHeaderUsingGeneratorFunction(_logger, correlationId);
             return correlationId;
         }
 
-        internal static class EventIds
+        correlationId = _correlationIdProvider.GenerateCorrelationId(ctx);
+        Log.GeneratedHeaderUsingProvider(_logger, correlationId, _correlationIdProvider.GetType());
+        return correlationId;
+    }
+
+    internal static class EventIds
+    {
+        public static readonly EventId CorrelationIdProcessingBegin = new(100, "CorrelationIdProcessingBegin");
+        public static readonly EventId CorrelationIdProcessingEnd = new(101, "CorrelationIdProcessingEnd");
+
+        public static readonly EventId MissingCorrelationIdProvider = new(103, "MissingCorrelationIdProvider");
+
+        public static readonly EventId EnforcedCorrelationIdHeaderMissing =
+            new(104, "EnforcedCorrelationIdHeaderMissing");
+
+        public static readonly EventId FoundCorrelationIdHeader = new(105, "EnforcedCorrelationIdHeaderMissing");
+        public static readonly EventId MissingCorrelationIdHeader = new(106, "MissingCorrelationIdHeader");
+
+        public static readonly EventId GeneratedHeaderUsingGeneratorFunction =
+            new(107, "GeneratedHeaderUsingGeneratorFunction");
+
+        public static readonly EventId GeneratedHeaderUsingProvider = new(108, "GeneratedHeaderUsingProvider");
+
+        public static readonly EventId UpdatingTraceIdentifier = new(109, "UpdatingTraceIdentifier");
+        public static readonly EventId CreatingCorrelationContext = new(110, "CreatingCorrelationContext");
+        public static readonly EventId DisposingCorrelationContext = new(111, "DisposingCorrelationContext");
+
+        public static readonly EventId WritingCorrelationIdResponseHeader =
+            new(112, "WritingCorrelationIdResponseHeader");
+    }
+
+    private static class Log
+    {
+        public static void CorrelationIdProcessingBegin(ILogger logger)
         {
-            public static readonly EventId CorrelationIdProcessingBegin = new EventId(100, "CorrelationIdProcessingBegin");
-            public static readonly EventId CorrelationIdProcessingEnd = new EventId(101, "CorrelationIdProcessingEnd");
-
-            public static readonly EventId MissingCorrelationIdProvider = new EventId(103, "MissingCorrelationIdProvider");
-            public static readonly EventId EnforcedCorrelationIdHeaderMissing = new EventId(104, "EnforcedCorrelationIdHeaderMissing");
-            public static readonly EventId FoundCorrelationIdHeader = new EventId(105, "EnforcedCorrelationIdHeaderMissing");
-            public static readonly EventId MissingCorrelationIdHeader = new EventId(106, "MissingCorrelationIdHeader");
-
-            public static readonly EventId GeneratedHeaderUsingGeneratorFunction = new EventId(107, "GeneratedHeaderUsingGeneratorFunction");
-            public static readonly EventId GeneratedHeaderUsingProvider = new EventId(108, "GeneratedHeaderUsingProvider");
-
-            public static readonly EventId UpdatingTraceIdentifier = new EventId(109, "UpdatingTraceIdentifier");
-            public static readonly EventId CreatingCorrelationContext = new EventId(110, "CreatingCorrelationContext");
-            public static readonly EventId DisposingCorrelationContext = new EventId(111, "DisposingCorrelationContext");
-            public static readonly EventId WritingCorrelationIdResponseHeader = new EventId(112, "WritingCorrelationIdResponseHeader");
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.Log(LogLevel.Debug, EventIds.CorrelationIdProcessingBegin, "Running correlation ID processing");
         }
 
-        private static class Log
+        public static void CorrelationIdProcessingEnd(ILogger logger, string correlationId)
         {
-            private static readonly Action<ILogger, Exception> _correlationIdProcessingBegin = LoggerMessage.Define(
-                LogLevel.Debug,
-                EventIds.CorrelationIdProcessingBegin,
-                "Running correlation ID processing");
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.Log(LogLevel.Debug, EventIds.CorrelationIdProcessingEnd,
+                    "Correlation ID processing was completed with a final correlation ID {CorrelationId}", correlationId);
+        }
 
-            private static readonly Action<ILogger, string, Exception> _correlationIdProcessingEnd = LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                EventIds.CorrelationIdProcessingEnd,
-                "Correlation ID processing was completed with a final correlation ID {CorrelationId}");
-
-            private static readonly Action<ILogger, Exception> _missingCorrelationIdProvider = LoggerMessage.Define(
-                LogLevel.Error,
-                EventIds.MissingCorrelationIdProvider,
+        public static void MissingCorrelationIdProvider(ILogger logger)
+        {
+            logger.Log(LogLevel.Error, EventIds.MissingCorrelationIdProvider,
                 "Correlation ID middleware was called when no ICorrelationIdProvider had been configured");
+        }
 
-            private static readonly Action<ILogger, Exception> _enforcedCorrelationIdHeaderMissing = LoggerMessage.Define(
-                LogLevel.Warning,
+        public static void EnforcedCorrelationIdHeaderMissing(ILogger logger)
+        {
+            logger.Log(LogLevel.Warning,
                 EventIds.EnforcedCorrelationIdHeaderMissing,
                 "Correlation ID header is enforced but no Correlation ID was not found in the request headers");
+        }
 
-            private static readonly Action<ILogger, string, Exception> _foundCorrelationIdHeader = LoggerMessage.Define<string>(
-                LogLevel.Information,
-                EventIds.FoundCorrelationIdHeader,
-                "Correlation ID {CorrelationId} was found in the request headers");
+        public static void FoundCorrelationIdHeader(ILogger logger, LogLevel logLevel, string correlationId)
+        {
+            logger.Log(logLevel, EventIds.FoundCorrelationIdHeader,
+                "Correlation ID {CorrelationId} was found in the request headers", correlationId);
+        }
 
-            private static readonly Action<ILogger, Exception> _missingCorrelationIdHeader = LoggerMessage.Define(
-                LogLevel.Information,
-                EventIds.MissingCorrelationIdHeader,
-                "No correlation ID was found in the request headers");
+        public static void MissingCorrelationIdHeader(ILogger logger, LogLevel logLevel)
+        {
+            logger.Log(logLevel, EventIds.MissingCorrelationIdHeader, "No correlation ID was found in the request headers");
+        }
 
-            private static readonly Action<ILogger, string, Exception> _generatedHeaderUsingGeneratorFunction = LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                EventIds.GeneratedHeaderUsingGeneratorFunction,
-                "Generated a correlation ID {CorrelationId} using the configured generator function");
+        public static void GeneratedHeaderUsingGeneratorFunction(ILogger logger, string correlationId)
+        {
+            logger.Log(LogLevel.Debug, EventIds.GeneratedHeaderUsingGeneratorFunction,
+                "Generated a correlation ID {CorrelationId} using the configured generator function", correlationId);
+        }
 
-            private static readonly Action<ILogger, string, Type, Exception> _generatedHeaderUsingProvider = LoggerMessage.Define<string, Type>(
-                LogLevel.Debug,
-                EventIds.GeneratedHeaderUsingProvider,
-                "Generated a correlation ID {CorrelationId} using the {Type} provider");
+        public static void GeneratedHeaderUsingProvider(ILogger logger, string correlationId, Type type)
+        {
+            logger.Log(LogLevel.Debug, EventIds.GeneratedHeaderUsingProvider,
+                "Generated a correlation ID {CorrelationId} using the {Type} provider", correlationId, type);
+        }
 
-            private static readonly Action<ILogger, Exception> _updatingTraceIdentifier = LoggerMessage.Define(
-                LogLevel.Debug,
-                EventIds.UpdatingTraceIdentifier,
+        public static void UpdatingTraceIdentifier(ILogger logger)
+        {
+            logger.Log(LogLevel.Debug, EventIds.UpdatingTraceIdentifier,
                 "Updating the TraceIdentifier value on the HttpContext");
+        }
 
-            private static readonly Action<ILogger, Exception> _creatingCorrelationContext = LoggerMessage.Define(
-                LogLevel.Debug,
-                EventIds.CreatingCorrelationContext,
+        public static void CreatingCorrelationContext(ILogger logger)
+        {
+            logger.Log(LogLevel.Debug, EventIds.CreatingCorrelationContext,
                 "Creating the correlation context for this request");
+        }
 
-            private static readonly Action<ILogger, Exception> _disposingCorrelationContext = LoggerMessage.Define(
-                LogLevel.Debug,
-                EventIds.DisposingCorrelationContext,
+        public static void DisposingCorrelationContext(ILogger logger)
+        {
+            logger.Log(LogLevel.Debug, EventIds.DisposingCorrelationContext,
                 "Disposing the correlation context for this request");
+        }
 
-            private static readonly Action<ILogger, string, string, Exception> _writingCorrelationIdResponseHeader = LoggerMessage.Define<string, string>(
-                LogLevel.Debug,
-                EventIds.WritingCorrelationIdResponseHeader,
-                "Writing correlation ID response header {ResponseHeader} with value {CorrelationId}");
-
-            public static void CorrelationIdProcessingBegin(ILogger logger)
-            {
-                if(logger.IsEnabled(LogLevel.Debug)) _correlationIdProcessingBegin(logger, null);
-            }
-
-            public static void CorrelationIdProcessingEnd(ILogger logger, string correlationId)
-            {
-                if (logger.IsEnabled(LogLevel.Debug)) _correlationIdProcessingEnd(logger, correlationId, null);
-            }
-
-            public static void MissingCorrelationIdProvider(ILogger logger) => _missingCorrelationIdProvider(logger, null);
-
-            public static void EnforcedCorrelationIdHeaderMissing(ILogger logger) => _enforcedCorrelationIdHeaderMissing(logger, null);
-
-            public static void FoundCorrelationIdHeader(ILogger logger, string correlationId) => _foundCorrelationIdHeader(logger, correlationId, null);
-
-            public static void MissingCorrelationIdHeader(ILogger logger) => _missingCorrelationIdHeader(logger, null);
-
-            public static void GeneratedHeaderUsingGeneratorFunction(ILogger logger, string correlationId) => _generatedHeaderUsingGeneratorFunction(logger, correlationId, null);
-
-            public static void GeneratedHeaderUsingProvider(ILogger logger, string correlationId, Type type) => _generatedHeaderUsingProvider(logger, correlationId, type, null);
-
-            public static void UpdatingTraceIdentifier(ILogger logger) => _updatingTraceIdentifier(logger, null);
-
-            public static void CreatingCorrelationContext(ILogger logger) => _creatingCorrelationContext(logger, null);
-
-            public static void DisposingCorrelationContext(ILogger logger) => _disposingCorrelationContext(logger, null);
-
-            public static void WritingCorrelationIdResponseHeader(ILogger logger, string headerName, string correlationId) => _writingCorrelationIdResponseHeader(logger, headerName, correlationId, null);
+        public static void WritingCorrelationIdResponseHeader(ILogger logger, string headerName, string correlationId)
+        {
+            logger.Log(LogLevel.Debug, EventIds.WritingCorrelationIdResponseHeader,
+                "Writing correlation ID response header {ResponseHeader} with value {CorrelationId}", headerName,
+                correlationId);
         }
     }
 }

--- a/src/CorrelationId/CorrelationIdMiddleware.cs
+++ b/src/CorrelationId/CorrelationIdMiddleware.cs
@@ -77,7 +77,7 @@ public class CorrelationIdMiddleware
             Log.MissingCorrelationIdHeader(_logger, _options.LogLevelOptions.MissingCorrelationIdHeader);
 
         if (_options.IgnoreRequestHeader || RequiresGenerationOfCorrelationId(hasCorrelationIdHeader, cid))
-            correlationId = GenerateCorrelationId(httpContext);
+            correlationId = GenerateCorrelationId();
 
         if (!string.IsNullOrEmpty(correlationId) && _options.UpdateTraceIdentifier)
         {
@@ -128,7 +128,7 @@ public class CorrelationIdMiddleware
         return !idInHeader || StringValues.IsNullOrEmpty(idFromHeader);
     }
 
-    private string GenerateCorrelationId(HttpContext ctx)
+    private string GenerateCorrelationId()
     {
         string correlationId;
 
@@ -139,7 +139,7 @@ public class CorrelationIdMiddleware
             return correlationId;
         }
 
-        correlationId = _correlationIdProvider.GenerateCorrelationId(ctx);
+        correlationId = _correlationIdProvider.GenerateCorrelationId();
         Log.GeneratedHeaderUsingProvider(_logger, correlationId, _correlationIdProvider.GetType());
         return correlationId;
     }

--- a/src/CorrelationId/CorrelationIdOptions.cs
+++ b/src/CorrelationId/CorrelationIdOptions.cs
@@ -1,90 +1,115 @@
-﻿using System;
-using CorrelationId.Abstractions;
+﻿using CorrelationId.Abstractions;
+using Microsoft.Extensions.Logging;
 
-namespace CorrelationId
+namespace CorrelationId;
+
+/// <summary>
+///     Options for correlation IDs.
+/// </summary>
+public class CorrelationIdOptions
 {
     /// <summary>
-    /// Options for correlation IDs.
+    ///     The default header used for correlation ID.
     /// </summary>
-    public class CorrelationIdOptions
+    public const string DefaultHeader = "X-Correlation-ID";
+
+    /// <summary>
+    ///     The default logger scope key for correlation ID logging.
+    /// </summary>
+    public const string LoggerScopeKey = "CorrelationId";
+
+    private string _responseHeader;
+
+    /// <summary>
+    ///     The name of the header from which the Correlation ID is read from the request.
+    /// </summary>
+    public string RequestHeader { get; set; } = DefaultHeader;
+
+    /// <summary>
+    ///     The name of the header to which the Correlation ID is written for the response.
+    /// </summary>
+    public string ResponseHeader
     {
-        /// <summary>
-        /// The default header used for correlation ID.
-        /// </summary>
-        public const string DefaultHeader = "X-Correlation-ID";
-
-        /// <summary>
-        /// The default logger scope key for correlation ID logging.
-        /// </summary>
-        public const string LoggerScopeKey = "CorrelationId";
-
-        /// <summary>
-        /// The name of the header from which the Correlation ID is read from the request.
-        /// </summary>
-        public string RequestHeader { get; set; } = DefaultHeader;
-
-        private string _responseHeader = null;
-
-        /// <summary>
-        /// The name of the header to which the Correlation ID is written for the response.
-        /// </summary>
-        public string ResponseHeader { get => _responseHeader ?? RequestHeader; set => _responseHeader = value; }
-
-        /// <summary>
-        /// <para>
-        /// Ignore request header.
-        /// When true, the correlation ID for the current request ignores the correlation ID header value on the request.
-        /// </para>
-        /// <para>Default: false</para>
-        /// </summary>
-        public bool IgnoreRequestHeader { get; set; } = false;
-
-        /// <summary>
-        /// <para>
-        /// Enforce the inclusion of the correlation ID request header.
-        /// When true and a correlation ID header is not included, the request will fail with a 400 Bad Request response.
-        /// </para>
-        /// <para>Default: false</para>
-        /// </summary>
-        public bool EnforceHeader { get; set; } = false;
-
-        /// <summary>
-        /// <para>
-        /// Add the correlation ID value to the logger scope for all requests.
-        /// When true the value of the correlation ID will be added to the logger scope payload.
-        /// </para>
-        /// <para>Default: false</para>
-        /// </summary>
-        public bool AddToLoggingScope { get; set; } = false;
-
-        /// <summary>
-        /// <para>
-        /// The name for the key used when adding the correlation ID to the logger scope.
-        /// </para>
-        /// <para>Default: 'CorrelationId'</para>
-        /// </summary>
-        public string LoggingScopeKey { get; set; } = LoggerScopeKey;
-
-        /// <summary>
-        /// <para>
-        /// Controls whether the correlation ID is returned in the response headers.
-        /// </para>
-        /// <para>Default: true</para>
-        /// </summary>
-        public bool IncludeInResponse { get; set; } = true;
-
-        /// <summary>
-        /// <para>
-        /// Controls whether the ASP.NET Core TraceIdentifier will be set to match the CorrelationId.
-        /// </para>
-        /// <para>Default: false</para>
-        /// </summary>
-        public bool UpdateTraceIdentifier { get; set; } = false;
-
-        /// <summary>
-        /// A function that returns the correlation ID in cases where no correlation ID is retrieved from the request header. It can be used to customise the correlation ID generation.
-        /// When set, this function will be used instead of the registered <see cref="ICorrelationIdProvider"/>.
-        /// </summary>
-        public Func<string> CorrelationIdGenerator { get; set; }
+        get => _responseHeader ?? RequestHeader;
+        set => _responseHeader = value;
     }
+
+    /// <summary>
+    ///     <para>
+    ///         Ignore request header.
+    ///         When true, the correlation ID for the current request ignores the correlation ID header value on the request.
+    ///     </para>
+    ///     <para>Default: false</para>
+    /// </summary>
+    public bool IgnoreRequestHeader { get; set; } = false;
+
+    /// <summary>
+    ///     <para>
+    ///         Enforce the inclusion of the correlation ID request header.
+    ///         When true and a correlation ID header is not included, the request will fail with a 400 Bad Request response.
+    ///     </para>
+    ///     <para>Default: false</para>
+    /// </summary>
+    public bool EnforceHeader { get; set; } = false;
+
+    /// <summary>
+    ///     <para>
+    ///         Add the correlation ID value to the logger scope for all requests.
+    ///         When true the value of the correlation ID will be added to the logger scope payload.
+    ///     </para>
+    ///     <para>Default: false</para>
+    /// </summary>
+    public bool AddToLoggingScope { get; set; } = false;
+
+    /// <summary>
+    ///     <para>
+    ///         The name for the key used when adding the correlation ID to the logger scope.
+    ///     </para>
+    ///     <para>Default: 'CorrelationId'</para>
+    /// </summary>
+    public string LoggingScopeKey { get; set; } = LoggerScopeKey;
+
+    /// <summary>
+    ///     <para>
+    ///         Controls whether the correlation ID is returned in the response headers.
+    ///     </para>
+    ///     <para>Default: true</para>
+    /// </summary>
+    public bool IncludeInResponse { get; set; } = true;
+
+    /// <summary>
+    ///     <para>
+    ///         Controls whether the ASP.NET Core TraceIdentifier will be set to match the CorrelationId.
+    ///     </para>
+    ///     <para>Default: false</para>
+    /// </summary>
+    public bool UpdateTraceIdentifier { get; set; } = false;
+
+    /// <summary>
+    ///     A function that returns the correlation ID in cases where no correlation ID is retrieved from the request header.
+    ///     It can be used to customise the correlation ID generation.
+    ///     When set, this function will be used instead of the registered <see cref="ICorrelationIdProvider" />.
+    /// </summary>
+    public Func<string> CorrelationIdGenerator { get; set; }
+
+    /// <summary>
+    ///     Defines the log level severity
+    /// </summary>
+    public CorrelationIdLogLevelOptions LogLevelOptions = new();
+
+    ///// <summary>
+    /////     <para>
+    /////         Defines the log level severity when a correlation Id is found on the header.
+    /////     </para>
+    /////     <para>Default: LogLevel.Information</para>
+    ///// </summary>
+    //public LogLevel FoundCorrelationIdHeaderLogLevel { get; set; } = LogLevel.Information;
+
+    ///// <summary>
+    /////     <para>
+    /////         Defines the log level severity when a correlation Id is missing on the header.
+    /////     </para>
+    /////     <para>Default: LogLevel.Information</para>
+    ///// </summary>
+    //public LogLevel MissingCorrelationIdHeaderLogLevel { get; set; } = LogLevel.Information;
 }

--- a/src/CorrelationId/CorrelationIdOptions.cs
+++ b/src/CorrelationId/CorrelationIdOptions.cs
@@ -1,5 +1,4 @@
 ﻿using CorrelationId.Abstractions;
-using Microsoft.Extensions.Logging;
 
 namespace CorrelationId;
 
@@ -19,6 +18,11 @@ public class CorrelationIdOptions
     public const string LoggerScopeKey = "CorrelationId";
 
     private string _responseHeader;
+
+    /// <summary>
+    ///     Defines the log level severity
+    /// </summary>
+    public CorrelationIdLogLevelOptions LogLevelOptions = new();
 
     /// <summary>
     ///     The name of the header from which the Correlation ID is read from the request.
@@ -91,11 +95,6 @@ public class CorrelationIdOptions
     ///     When set, this function will be used instead of the registered <see cref="ICorrelationIdProvider" />.
     /// </summary>
     public Func<string> CorrelationIdGenerator { get; set; }
-
-    /// <summary>
-    ///     Defines the log level severity
-    /// </summary>
-    public CorrelationIdLogLevelOptions LogLevelOptions = new();
 
     ///// <summary>
     /////     <para>

--- a/src/CorrelationId/DependencyInjection/CorrelationIdBuilder.cs
+++ b/src/CorrelationId/DependencyInjection/CorrelationIdBuilder.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace CorrelationId.DependencyInjection
-{
-    /// <inheritdoc />
-    internal class CorrelationIdBuilder : ICorrelationIdBuilder
-    {
-        public CorrelationIdBuilder(IServiceCollection services)
-        {
-            Services = services;
-        }
+namespace CorrelationId.DependencyInjection;
 
-        /// <inheritdoc />
-        public IServiceCollection Services { get; }
+/// <inheritdoc />
+internal class CorrelationIdBuilder : ICorrelationIdBuilder
+{
+    public CorrelationIdBuilder(IServiceCollection services)
+    {
+        Services = services;
     }
+
+    /// <inheritdoc />
+    public IServiceCollection Services { get; }
 }

--- a/src/CorrelationId/DependencyInjection/CorrelationIdBuilderExtensions.cs
+++ b/src/CorrelationId/DependencyInjection/CorrelationIdBuilderExtensions.cs
@@ -1,137 +1,124 @@
 ﻿using CorrelationId.Abstractions;
 using CorrelationId.Providers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
-using System.Linq;
 
-namespace CorrelationId.DependencyInjection
+namespace CorrelationId.DependencyInjection;
+
+/// <summary>
+///     Provides basic extension methods for configuring the correlation ID provider in an
+///     <see cref="ICorrelationIdBuilder" />.
+/// </summary>
+public static class CorrelationIdBuilderExtensions
 {
+    private const string MultipleProviderExceptionMessage =
+        "A provider has already been registered. Only a single provider may be registered.";
+
     /// <summary>
-    /// Provides basic extension methods for configuring the correlation ID provider in an <see cref="ICorrelationIdBuilder"/>.
+    ///     Clear the existing <see cref="ICorrelationIdProvider" /> if one has been registered.
     /// </summary>
-    public static class CorrelationIdBuilderExtensions
+    /// <param name="builder">The <see cref="ICorrelationIdBuilder" />.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder" /> parameter is null.</exception>
+    public static ICorrelationIdBuilder ClearProvider(this ICorrelationIdBuilder builder)
     {
-        private const string MultipleProviderExceptionMessage = "A provider has already been registered. Only a single provider may be registered.";
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-        /// <summary>
-        /// Clear the existing <see cref="ICorrelationIdProvider"/> if one has been registered.
-        /// </summary>
-        /// <param name="builder">The <see cref="ICorrelationIdBuilder"/>.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> parameter is null.</exception>
-        public static ICorrelationIdBuilder ClearProvider(this ICorrelationIdBuilder builder)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+        builder.Services.RemoveAll<ICorrelationIdProvider>();
 
-            builder.Services.RemoveAll<ICorrelationIdProvider>();
+        return builder;
+    }
 
-            return builder;
-        }
+    /// <summary>
+    ///     Registers the <see cref="GuidCorrelationIdProvider" /> for use when generating correlation IDs.
+    /// </summary>
+    /// <param name="builder">The <see cref="ICorrelationIdBuilder" />.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder" /> parameter is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if a <see cref="ICorrelationIdProvider" /> has already been
+    ///     registered.
+    /// </exception>
+    public static ICorrelationIdBuilder WithGuidProvider(this ICorrelationIdBuilder builder)
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-        /// <summary>
-        /// Registers the <see cref="GuidCorrelationIdProvider"/> for use when generating correlation IDs.
-        /// </summary>
-        /// <param name="builder">The <see cref="ICorrelationIdBuilder"/>.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> parameter is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if a <see cref="ICorrelationIdProvider"/> has already been registered.</exception>
-        public static ICorrelationIdBuilder WithGuidProvider(this ICorrelationIdBuilder builder)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+        if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
+            throw new InvalidOperationException(MultipleProviderExceptionMessage);
 
-            if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
-            {
-                throw new InvalidOperationException(MultipleProviderExceptionMessage);
-            }
+        builder.Services.TryAddSingleton<ICorrelationIdProvider, GuidCorrelationIdProvider>();
 
-            builder.Services.TryAddSingleton<ICorrelationIdProvider, GuidCorrelationIdProvider>();
+        return builder;
+    }
 
-            return builder;
-        }
+    /// <summary>
+    ///     Registers the <see cref="TraceIdCorrelationIdProvider" /> for use when generating correlation IDs.
+    /// </summary>
+    /// <param name="builder">The <see cref="ICorrelationIdBuilder" />.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder" /> parameter is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if a <see cref="ICorrelationIdProvider" /> has already been
+    ///     registered.
+    /// </exception>
+    public static ICorrelationIdBuilder WithTraceIdentifierProvider(this ICorrelationIdBuilder builder)
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-        /// <summary>
-        /// Registers the <see cref="TraceIdCorrelationIdProvider"/> for use when generating correlation IDs.
-        /// </summary>
-        /// <param name="builder">The <see cref="ICorrelationIdBuilder"/>.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> parameter is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if a <see cref="ICorrelationIdProvider"/> has already been registered.</exception>
-        public static ICorrelationIdBuilder WithTraceIdentifierProvider(this ICorrelationIdBuilder builder)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+        if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
+            throw new InvalidOperationException("A provider has already been added.");
 
-            if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
-            {
-                throw new InvalidOperationException("A provider has already been added.");
-            }
+        builder.Services.TryAddSingleton<ICorrelationIdProvider, TraceIdCorrelationIdProvider>();
 
-            builder.Services.TryAddSingleton<ICorrelationIdProvider, TraceIdCorrelationIdProvider>();
+        return builder;
+    }
 
-            return builder;
-        }
+    /// <summary>
+    ///     Registers an existing instance of a custom <see cref="ICorrelationIdProvider" />.
+    /// </summary>
+    /// <param name="builder">The <see cref="ICorrelationIdBuilder" />.</param>
+    /// <param name="provider">The <see cref="ICorrelationIdProvider" /> instance to register.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder" /> parameter is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if a <see cref="ICorrelationIdProvider" /> has already been
+    ///     registered.
+    /// </exception>
+    public static ICorrelationIdBuilder WithCustomProvider(this ICorrelationIdBuilder builder,
+        ICorrelationIdProvider provider)
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-        /// <summary>
-        /// Registers an existing instance of a custom <see cref="ICorrelationIdProvider"/>.
-        /// </summary>
-        /// <param name="builder">The <see cref="ICorrelationIdBuilder"/>.</param>
-        /// <param name="provider">The <see cref="ICorrelationIdProvider"/> instance to register.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> parameter is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if a <see cref="ICorrelationIdProvider"/> has already been registered.</exception>
-        public static ICorrelationIdBuilder WithCustomProvider(this ICorrelationIdBuilder builder, ICorrelationIdProvider provider)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+        if (provider is null) throw new ArgumentNullException(nameof(provider));
 
-            if (provider is null)
-            {
-                throw new ArgumentNullException(nameof(provider));
-            }
+        if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
+            throw new InvalidOperationException("A provider has already been added.");
 
-            if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
-            {
-                throw new InvalidOperationException("A provider has already been added.");
-            }
+        builder.Services.TryAddSingleton(provider);
 
-            builder.Services.TryAddSingleton<ICorrelationIdProvider>(provider);
+        return builder;
+    }
 
-            return builder;
-        }
+    /// <summary>
+    ///     Registers a custom <see cref="ICorrelationIdProvider" />.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="ICorrelationIdProvider" /> implementation type.</typeparam>
+    /// <param name="builder">The <see cref="ICorrelationIdBuilder" />.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder" /> parameter is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if a <see cref="ICorrelationIdProvider" /> has already been
+    ///     registered.
+    /// </exception>
+    public static ICorrelationIdBuilder WithCustomProvider<T>(this ICorrelationIdBuilder builder)
+        where T : class, ICorrelationIdProvider
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-        /// <summary>
-        /// Registers a custom <see cref="ICorrelationIdProvider"/>.
-        /// </summary>
-        /// <typeparam name="T">The <see cref="ICorrelationIdProvider"/> implementation type.</typeparam>
-        /// <param name="builder">The <see cref="ICorrelationIdBuilder"/>.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> parameter is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if a <see cref="ICorrelationIdProvider"/> has already been registered.</exception>
-        public static ICorrelationIdBuilder WithCustomProvider<T>(this ICorrelationIdBuilder builder) where T : class, ICorrelationIdProvider
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+        if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
+            throw new InvalidOperationException("A provider has already been added.");
 
-            if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
-            {
-                throw new InvalidOperationException("A provider has already been added.");
-            }
+        builder.Services.TryAddSingleton<ICorrelationIdProvider, T>();
 
-            builder.Services.TryAddSingleton<ICorrelationIdProvider, T>();
-
-            return builder;
-        }
+        return builder;
     }
 }

--- a/src/CorrelationId/DependencyInjection/CorrelationIdBuilderExtensions.cs
+++ b/src/CorrelationId/DependencyInjection/CorrelationIdBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using CorrelationId.Abstractions;
 using CorrelationId.Providers;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace CorrelationId.DependencyInjection;
@@ -67,6 +68,7 @@ public static class CorrelationIdBuilderExtensions
         if (builder.Services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
             throw new InvalidOperationException("A provider has already been added.");
 
+        builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         builder.Services.TryAddSingleton<ICorrelationIdProvider, TraceIdCorrelationIdProvider>();
 
         return builder;

--- a/src/CorrelationId/DependencyInjection/CorrelationIdServiceCollectionExtensions.cs
+++ b/src/CorrelationId/DependencyInjection/CorrelationIdServiceCollectionExtensions.cs
@@ -1,181 +1,174 @@
-﻿using System;
-using System.Linq;
-using CorrelationId.Abstractions;
+﻿using CorrelationId.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace CorrelationId.DependencyInjection
+namespace CorrelationId.DependencyInjection;
+
+/// <summary>
+///     Extensions on the <see cref="IServiceCollection" /> to register the correlation ID services.
+/// </summary>
+public static class CorrelationIdServiceCollectionExtensions
 {
     /// <summary>
-    /// Extensions on the <see cref="IServiceCollection"/> to register the correlation ID services.
+    ///     Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection" />.
     /// </summary>
-    public static class CorrelationIdServiceCollectionExtensions
+    /// <remarks>
+    ///     This operation is idempotent - multiple invocations will still only result in a single
+    ///     instance of the required services in the <see cref="IServiceCollection" />. It can be invoked
+    ///     multiple times in order to get access to the <see cref="ICorrelationIdBuilder" /> in multiple places.
+    /// </remarks>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the correlation ID services to.</param>
+    /// <returns>
+    ///     An instance of <see cref="ICorrelationIdBuilder" /> which to be used to configure correlation ID providers and
+    ///     options.
+    /// </returns>
+    public static ICorrelationIdBuilder AddCorrelationId(this IServiceCollection services)
     {
-        /// <summary>
-        /// Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// This operation is idempotent - multiple invocations will still only result in a single
-        /// instance of the required services in the <see cref="IServiceCollection"/>. It can be invoked
-        /// multiple times in order to get access to the <see cref="ICorrelationIdBuilder"/> in multiple places.
-        /// </remarks>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the correlation ID services to.</param>
-        /// <returns>An instance of <see cref="ICorrelationIdBuilder"/> which to be used to configure correlation ID providers and options.</returns>
-        public static ICorrelationIdBuilder AddCorrelationId(this IServiceCollection services)
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+        if (services is null) throw new ArgumentNullException(nameof(services));
 
-            services.TryAddSingleton<ICorrelationContextAccessor, CorrelationContextAccessor>();
-            services.TryAddTransient<ICorrelationContextFactory, CorrelationContextFactory>();
+        services.TryAddSingleton<ICorrelationContextAccessor, CorrelationContextAccessor>();
+        services.TryAddTransient<ICorrelationContextFactory, CorrelationContextFactory>();
 
-            return new CorrelationIdBuilder(services);
-        }
+        return new CorrelationIdBuilder(services);
+    }
 
-        /// <summary>
-        /// Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// This operation is idempotent - multiple invocations will still only result in a single
-        /// instance of the required services in the <see cref="IServiceCollection"/>. It can be invoked
-        /// multiple times in order to get access to the <see cref="ICorrelationIdBuilder"/> in multiple places.
-        /// </remarks>
-        /// <typeparam name="T">The <see cref="ICorrelationIdProvider"/> implementation type.</typeparam>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the correlation ID services to.</param>
-        /// <returns>An instance of <see cref="ICorrelationIdBuilder"/> which to be used to configure correlation ID providers and options.</returns>
-        public static ICorrelationIdBuilder AddCorrelationId<T>(this IServiceCollection services) where T : class, ICorrelationIdProvider
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+    /// <summary>
+    ///     Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     This operation is idempotent - multiple invocations will still only result in a single
+    ///     instance of the required services in the <see cref="IServiceCollection" />. It can be invoked
+    ///     multiple times in order to get access to the <see cref="ICorrelationIdBuilder" /> in multiple places.
+    /// </remarks>
+    /// <typeparam name="T">The <see cref="ICorrelationIdProvider" /> implementation type.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the correlation ID services to.</param>
+    /// <returns>
+    ///     An instance of <see cref="ICorrelationIdBuilder" /> which to be used to configure correlation ID providers and
+    ///     options.
+    /// </returns>
+    public static ICorrelationIdBuilder AddCorrelationId<T>(this IServiceCollection services)
+        where T : class, ICorrelationIdProvider
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
 
-            if (services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
-            {
-                throw new InvalidOperationException("A provider has already been added.");
-            }
+        if (services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
+            throw new InvalidOperationException("A provider has already been added.");
 
-            var builder = AddCorrelationId(services);
+        var builder = AddCorrelationId(services);
 
-            builder.Services.TryAddSingleton<ICorrelationIdProvider, T>();
+        builder.Services.TryAddSingleton<ICorrelationIdProvider, T>();
 
-            return builder;
-        }
-               
-        /// <summary>
-        /// Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// This operation is idempotent - multiple invocations will still only result in a single
-        /// instance of the required services in the <see cref="IServiceCollection"/>. It can be invoked
-        /// multiple times in order to get access to the <see cref="ICorrelationIdBuilder"/> in multiple places.
-        /// </remarks>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the correlation ID services to.</param>
-        /// <param name="configure">The <see cref="Action{CorrelationIdOptions}"/> to configure the provided <see cref="CorrelationIdOptions"/>.</param>
-        /// <returns>An instance of <see cref="ICorrelationIdBuilder"/> which to be used to configure correlation ID providers and options.</returns>
-        public static ICorrelationIdBuilder AddCorrelationId(this IServiceCollection services, Action<CorrelationIdOptions> configure)
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+        return builder;
+    }
 
-            if (configure is null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-            
-            services.Configure(configure);
+    /// <summary>
+    ///     Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     This operation is idempotent - multiple invocations will still only result in a single
+    ///     instance of the required services in the <see cref="IServiceCollection" />. It can be invoked
+    ///     multiple times in order to get access to the <see cref="ICorrelationIdBuilder" /> in multiple places.
+    /// </remarks>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the correlation ID services to.</param>
+    /// <param name="configure">
+    ///     The <see cref="Action{CorrelationIdOptions}" /> to configure the provided
+    ///     <see cref="CorrelationIdOptions" />.
+    /// </param>
+    /// <returns>
+    ///     An instance of <see cref="ICorrelationIdBuilder" /> which to be used to configure correlation ID providers and
+    ///     options.
+    /// </returns>
+    public static ICorrelationIdBuilder AddCorrelationId(this IServiceCollection services,
+        Action<CorrelationIdOptions> configure)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
 
-            return services.AddCorrelationId();
-        }
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
 
-        /// <summary>
-        /// Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// This operation is idempotent - multiple invocations will still only result in a single
-        /// instance of the required services in the <see cref="IServiceCollection"/>. It can be invoked
-        /// multiple times in order to get access to the <see cref="ICorrelationIdBuilder"/> in multiple places.
-        /// </remarks>
-        /// <typeparam name="T">The <see cref="ICorrelationIdProvider"/> implementation type.</typeparam>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the correlation ID services to.</param>
-        /// <param name="configure">The <see cref="Action{CorrelationIdOptions}"/> to configure the provided <see cref="CorrelationIdOptions"/>.</param>
-        /// <returns>An instance of <see cref="ICorrelationIdBuilder"/> which to be used to configure correlation ID providers and options.</returns>
-        public static ICorrelationIdBuilder AddCorrelationId<T>(this IServiceCollection services, Action<CorrelationIdOptions> configure) where T : class, ICorrelationIdProvider
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+        services.Configure(configure);
 
-            if (services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
-            {
-                throw new InvalidOperationException("A provider has already been added.");
-            }
+        return services.AddCorrelationId();
+    }
 
-            if (configure is null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
+    /// <summary>
+    ///     Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     This operation is idempotent - multiple invocations will still only result in a single
+    ///     instance of the required services in the <see cref="IServiceCollection" />. It can be invoked
+    ///     multiple times in order to get access to the <see cref="ICorrelationIdBuilder" /> in multiple places.
+    /// </remarks>
+    /// <typeparam name="T">The <see cref="ICorrelationIdProvider" /> implementation type.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the correlation ID services to.</param>
+    /// <param name="configure">
+    ///     The <see cref="Action{CorrelationIdOptions}" /> to configure the provided
+    ///     <see cref="CorrelationIdOptions" />.
+    /// </param>
+    /// <returns>
+    ///     An instance of <see cref="ICorrelationIdBuilder" /> which to be used to configure correlation ID providers and
+    ///     options.
+    /// </returns>
+    public static ICorrelationIdBuilder AddCorrelationId<T>(this IServiceCollection services,
+        Action<CorrelationIdOptions> configure) where T : class, ICorrelationIdProvider
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
 
-            services.Configure(configure);
-            
-            return services.AddCorrelationId<T>();
-        }
+        if (services.Any(x => x.ServiceType == typeof(ICorrelationIdProvider)))
+            throw new InvalidOperationException("A provider has already been added.");
 
-        /// <summary>
-        /// Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// This operation is may only be called once to avoid exceptions from attempting to add the default <see cref="ICorrelationIdProvider"/> multiple
-        /// times.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">Thrown if this is called multiple times.</exception>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the correlation ID services to.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        public static IServiceCollection AddDefaultCorrelationId(this IServiceCollection services)
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
 
-            services.AddCorrelationId().WithGuidProvider();
+        services.Configure(configure);
 
-            return services;
-        }
+        return services.AddCorrelationId<T>();
+    }
 
-        /// <summary>
-        /// Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <remarks>
-        /// This operation is may only be called once to avoid exceptions from attempting to add the default <see cref="ICorrelationIdProvider"/> multiple
-        /// times.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">Thrown if this is called multiple times.</exception>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the correlation ID services to.</param>
-        /// <param name="configure">The <see cref="Action{CorrelationIdOptions}"/> to configure the provided <see cref="CorrelationIdOptions"/>.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        public static IServiceCollection AddDefaultCorrelationId(this IServiceCollection services, Action<CorrelationIdOptions> configure)
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+    /// <summary>
+    ///     Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     This operation is may only be called once to avoid exceptions from attempting to add the default
+    ///     <see cref="ICorrelationIdProvider" /> multiple
+    ///     times.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown if this is called multiple times.</exception>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the correlation ID services to.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddDefaultCorrelationId(this IServiceCollection services)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
 
-            if (configure is null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
+        services.AddCorrelationId().WithGuidProvider();
 
-            services.AddDefaultCorrelationId();
+        return services;
+    }
 
-            services.Configure(configure);
+    /// <summary>
+    ///     Adds required services to support the Correlation ID functionality to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     This operation is may only be called once to avoid exceptions from attempting to add the default
+    ///     <see cref="ICorrelationIdProvider" /> multiple
+    ///     times.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown if this is called multiple times.</exception>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the correlation ID services to.</param>
+    /// <param name="configure">
+    ///     The <see cref="Action{CorrelationIdOptions}" /> to configure the provided
+    ///     <see cref="CorrelationIdOptions" />.
+    /// </param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddDefaultCorrelationId(this IServiceCollection services,
+        Action<CorrelationIdOptions> configure)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
 
-            return services;
-        }
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
+
+        services.AddDefaultCorrelationId();
+
+        services.Configure(configure);
+
+        return services;
     }
 }

--- a/src/CorrelationId/DependencyInjection/ICorrelationIdBuilder.cs
+++ b/src/CorrelationId/DependencyInjection/ICorrelationIdBuilder.cs
@@ -1,15 +1,14 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace CorrelationId.DependencyInjection
+namespace CorrelationId.DependencyInjection;
+
+/// <summary>
+///     A builder used to configure the correlation ID services.
+/// </summary>
+public interface ICorrelationIdBuilder
 {
     /// <summary>
-    /// A builder used to configure the correlation ID services.
+    ///     Gets the <see cref="IServiceCollection" /> into which the correlation ID services will be registered.
     /// </summary>
-    public interface ICorrelationIdBuilder
-    {
-        /// <summary>
-        /// Gets the <see cref="IServiceCollection"/> into which the correlation ID services will be registered.
-        /// </summary>
-        IServiceCollection Services { get; }
-    }
+    IServiceCollection Services { get; }
 }

--- a/src/CorrelationId/HttpClient/CorrelationIdHandler.cs
+++ b/src/CorrelationId/HttpClient/CorrelationIdHandler.cs
@@ -1,30 +1,30 @@
-﻿using System.Net.Http;
-using CorrelationId.Abstractions;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using CorrelationId.Abstractions;
 
-namespace CorrelationId.HttpClient
+namespace CorrelationId.HttpClient;
+
+/// <summary>
+///     A <see cref="DelegatingHandler" /> which adds the correlation ID header from the <see cref="CorrelationContext" />
+///     onto outgoing HTTP requests.
+/// </summary>
+internal sealed class CorrelationIdHandler : DelegatingHandler
 {
-    /// <summary>
-    /// A <see cref="DelegatingHandler"/> which adds the correlation ID header from the <see cref="CorrelationContext"/> onto outgoing HTTP requests.
-    /// </summary>
-    internal sealed class CorrelationIdHandler : DelegatingHandler
+    private readonly ICorrelationContextAccessor _correlationContextAccessor;
+
+    public CorrelationIdHandler(ICorrelationContextAccessor correlationContextAccessor)
     {
-        private readonly ICorrelationContextAccessor _correlationContextAccessor;
-        
-        public CorrelationIdHandler(ICorrelationContextAccessor correlationContextAccessor) => _correlationContextAccessor = correlationContextAccessor;
+        _correlationContextAccessor = correlationContextAccessor;
+    }
 
-        /// <inheritdoc cref="DelegatingHandler"/>
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            string correlationId = _correlationContextAccessor?.CorrelationContext?.CorrelationId;
-            if (!string.IsNullOrEmpty(correlationId) 
-                && !request.Headers.Contains(_correlationContextAccessor.CorrelationContext.Header))
-            {
-                request.Headers.Add(_correlationContextAccessor.CorrelationContext.Header, _correlationContextAccessor.CorrelationContext.CorrelationId);
-            }
+    /// <inheritdoc cref="DelegatingHandler" />
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = _correlationContextAccessor?.CorrelationContext?.CorrelationId;
+        if (!string.IsNullOrEmpty(correlationId)
+            && !request.Headers.Contains(_correlationContextAccessor.CorrelationContext.Header))
+            request.Headers.Add(_correlationContextAccessor.CorrelationContext.Header,
+                _correlationContextAccessor.CorrelationContext.CorrelationId);
 
-            return base.SendAsync(request, cancellationToken);
-        }
+        return base.SendAsync(request, cancellationToken);
     }
 }

--- a/src/CorrelationId/HttpClient/HttpClientBuilderExtensions.cs
+++ b/src/CorrelationId/HttpClient/HttpClientBuilderExtensions.cs
@@ -1,33 +1,28 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace CorrelationId.HttpClient
+namespace CorrelationId.HttpClient;
+
+/// <summary>
+///     Extension methods for <see cref="IHttpClientBuilder" />.
+/// </summary>
+public static class HttpClientBuilderExtensions
 {
     /// <summary>
-    /// Extension methods for <see cref="IHttpClientBuilder"/>.
+    ///     Adds a handler which forwards the correlation ID by attaching it to the headers on outgoing requests.
     /// </summary>
-    public static class HttpClientBuilderExtensions
+    /// <remarks>
+    ///     The header name will match the name of the incoming request header.
+    /// </remarks>
+    /// <param name="builder">The <see cref="IHttpClientBuilder" />.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IHttpClientBuilder AddCorrelationIdForwarding(this IHttpClientBuilder builder)
     {
-        /// <summary>
-        /// Adds a handler which forwards the correlation ID by attaching it to the headers on outgoing requests.
-        /// </summary>
-        /// <remarks>
-        /// The header name will match the name of the incoming request header.
-        /// </remarks>
-        /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        public static IHttpClientBuilder AddCorrelationIdForwarding(this IHttpClientBuilder builder)
-        {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-            builder.Services.TryAddTransient<CorrelationIdHandler>();
-            builder.AddHttpMessageHandler<CorrelationIdHandler>();
-            
-            return builder;
-        }
+        builder.Services.TryAddTransient<CorrelationIdHandler>();
+        builder.AddHttpMessageHandler<CorrelationIdHandler>();
+
+        return builder;
     }
 }

--- a/src/CorrelationId/Properties/launchSettings.json
+++ b/src/CorrelationId/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51486/",
+      "sslPort": 44386
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "CorrelationId": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/src/CorrelationId/Providers/GuidCorrelationIdProvider.cs
+++ b/src/CorrelationId/Providers/GuidCorrelationIdProvider.cs
@@ -1,5 +1,4 @@
 ﻿using CorrelationId.Abstractions;
-using Microsoft.AspNetCore.Http;
 
 namespace CorrelationId.Providers;
 
@@ -9,7 +8,7 @@ namespace CorrelationId.Providers;
 public class GuidCorrelationIdProvider : ICorrelationIdProvider
 {
     /// <inheritdoc />
-    public string GenerateCorrelationId(HttpContext httpContext)
+    public string GenerateCorrelationId()
     {
         return Guid.NewGuid().ToString();
     }

--- a/src/CorrelationId/Providers/GuidCorrelationIdProvider.cs
+++ b/src/CorrelationId/Providers/GuidCorrelationIdProvider.cs
@@ -1,15 +1,16 @@
-﻿using System;
-using CorrelationId.Abstractions;
+﻿using CorrelationId.Abstractions;
 using Microsoft.AspNetCore.Http;
 
-namespace CorrelationId.Providers
+namespace CorrelationId.Providers;
+
+/// <summary>
+///     Generates a correlation ID using a new GUID.
+/// </summary>
+public class GuidCorrelationIdProvider : ICorrelationIdProvider
 {
-    /// <summary>
-    /// Generates a correlation ID using a new GUID.
-    /// </summary>
-    public class GuidCorrelationIdProvider : ICorrelationIdProvider
+    /// <inheritdoc />
+    public string GenerateCorrelationId(HttpContext httpContext)
     {
-        /// <inheritdoc />
-        public string GenerateCorrelationId(HttpContext ctx) => Guid.NewGuid().ToString();
+        return Guid.NewGuid().ToString();
     }
 }

--- a/src/CorrelationId/Providers/TraceIdCorrelationIdProvider.cs
+++ b/src/CorrelationId/Providers/TraceIdCorrelationIdProvider.cs
@@ -8,9 +8,19 @@ namespace CorrelationId.Providers;
 /// </summary>
 public class TraceIdCorrelationIdProvider : ICorrelationIdProvider
 {
-    /// <inheritdoc />
-    public string GenerateCorrelationId(HttpContext httpContext)
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    /// <summary>
+    /// </summary>
+    /// <param name="httpContextAccessor"></param>
+    public TraceIdCorrelationIdProvider(IHttpContextAccessor httpContextAccessor)
     {
-        return httpContext.TraceIdentifier;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <inheritdoc />
+    public string GenerateCorrelationId()
+    {
+        return _httpContextAccessor.HttpContext?.TraceIdentifier;
     }
 }

--- a/src/CorrelationId/Providers/TraceIdCorrelationIdProvider.cs
+++ b/src/CorrelationId/Providers/TraceIdCorrelationIdProvider.cs
@@ -1,14 +1,16 @@
 ﻿using CorrelationId.Abstractions;
 using Microsoft.AspNetCore.Http;
 
-namespace CorrelationId.Providers
+namespace CorrelationId.Providers;
+
+/// <summary>
+///     Sets the correlation ID to match the TraceIdentifier set on the <see cref="HttpContext" />.
+/// </summary>
+public class TraceIdCorrelationIdProvider : ICorrelationIdProvider
 {
-    /// <summary>
-    /// Sets the correlation ID to match the TraceIdentifier set on the <see cref="HttpContext"/>.
-    /// </summary>
-    public class TraceIdCorrelationIdProvider : ICorrelationIdProvider
+    /// <inheritdoc />
+    public string GenerateCorrelationId(HttpContext httpContext)
     {
-        /// <inheritdoc />
-        public string GenerateCorrelationId(HttpContext ctx) => ctx.TraceIdentifier;
+        return httpContext.TraceIdentifier;
     }
 }

--- a/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
+++ b/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
@@ -1,653 +1,666 @@
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.TestHost;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
+using System.Net;
 using System.Text;
-using System.Threading.Tasks;
+using CorrelationId.Abstractions;
+using CorrelationId.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
-using System;
-using System.Net;
-using CorrelationId.Abstractions;
-using CorrelationId.DependencyInjection;
 
-namespace CorrelationId.Tests
+namespace CorrelationId.Tests;
+
+public class CorrelationIdMiddlewareTests
 {
-    public class CorrelationIdMiddlewareTests
+    [Fact]
+    public async Task Throws_WhenCorrelationIdProviderIsNotRegistered()
     {
-        [Fact]
-        public async Task Throws_WhenCorrelationIdProviderIsNotRegistered()
-        {
-            Exception exception = null;
+        Exception exception = null;
 
-            var builder = new WebHostBuilder()
-                .Configure(app =>
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use(async (ctx, next) =>
                 {
-                    app.Use(async (ctx, next) =>
+                    try
                     {
-                        try
-                        {
-                            await next.Invoke();
-                        }
-                        catch (Exception e)
-                        {
-                            exception = e;
-                        }                        
-                    });
-
-                    app.UseCorrelationId();
-                })
-                .ConfigureServices(sc => sc.AddCorrelationId());
-
-            using var server = new TestServer(builder);
-
-            await server.CreateClient().GetAsync("");
-
-            Assert.NotNull(exception);
-            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
-        }
-
-        [Fact]
-        public async Task DoesNotThrow_WhenCorrelationIdProviderIsRegistered()
-        {
-            Exception exception = null;
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Use(async (ctx, next) =>
+                        await next.Invoke();
+                    }
+                    catch (Exception e)
                     {
-                        try
-                        {
-                            await next.Invoke();
-                        }
-                        catch (Exception e)
-                        {
-                            exception = e;
-                        }
-                    });
-
-                    app.UseCorrelationId();
-                })
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId());
-
-            using var server = new TestServer(builder);
-
-            await server.CreateClient().GetAsync("");
-
-            Assert.Null(exception);
-        }
-
-        [Fact]
-        public async Task ReturnsBadRequest_WhenEnforceOptionSetToTrue_AndNoExistingHeaderIsSent()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.EnforceHeader = true));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task DoesNotReturnBadRequest_WhenEnforceOptionSetToFalse_AndNoExistingHeaderIsSent()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.EnforceHeader = false));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task IgnoresRequestHeader_WhenOptionIsTrue()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => { options.IgnoreRequestHeader = true; options.IncludeInResponse = true; }));;
-
-            using var server = new TestServer(builder);
-
-            var request = new HttpRequestMessage();
-            request.Headers.Add(CorrelationIdOptions.DefaultHeader, "ABC123");
-
-            var response = await server.CreateClient().SendAsync(request);
-
-            var header = response.Headers.GetValues(CorrelationIdOptions.DefaultHeader).FirstOrDefault();
-
-            Assert.NotEqual("ABC123", header);
-        }
-
-        [Fact]
-        public async Task DoesNotIgnoresRequestHeader_WhenOptionIsFalse()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => { options.IgnoreRequestHeader = false; options.IncludeInResponse = true; })); ;
-
-            using var server = new TestServer(builder);
-
-            var request = new HttpRequestMessage();
-            request.Headers.Add(CorrelationIdOptions.DefaultHeader, "ABC123");
-
-            var response = await server.CreateClient().SendAsync(request);
-
-            var header = response.Headers.GetValues(CorrelationIdOptions.DefaultHeader).FirstOrDefault();
-
-            Assert.Equal("ABC123", header);
-        }
-
-        [Fact]
-        public async Task ReturnsCorrelationIdInResponseHeader_WhenOptionSetToTrue()
-        {
-            var builder = new WebHostBuilder()
-               .Configure(app => app.UseCorrelationId())
-               .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.IncludeInResponse = true));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-            
-            var header = response.Headers.GetValues(CorrelationIdOptions.DefaultHeader);
-
-            Assert.NotNull(header);
-        }
-
-        [Fact]
-        public async Task DoesNotThrowException_WhenOptionSetToTrue_IfHeaderIsAlreadySet()
-        {
-            Exception exception = null;
-
-            var builder = new WebHostBuilder()
-               .Configure(app =>
-               {
-                   app.Use(async (ctx, next) =>
-                   {
-                       try
-                       {
-                           await next.Invoke();
-                       }
-                       catch (Exception e)
-                       {
-                           exception = e;
-                       }
-                   });
-
-                   app.UseCorrelationId();
-                   app.UseCorrelationId(); // header will already be set on this second use of the middleware
-               })
-               .ConfigureServices(sc => sc.AddDefaultCorrelationId());
-            
-            using var server = new TestServer(builder);
-
-            await server.CreateClient().GetAsync("");
-
-            Assert.Null(exception);
-        }
-
-        [Fact]
-        public async Task DoesNotReturnCorrelationIdInResponseHeader_WhenIncludeInResponseIsFalse()
-        {
-            string header = null;
-
-            var builder = new WebHostBuilder()
-               .Configure(app => app.UseCorrelationId())
-               .ConfigureServices(sc => sc.AddDefaultCorrelationId(options =>
-               {
-                   options.IncludeInResponse = false;
-                   header = options.RequestHeader;
-               }));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var headerExists = response.Headers.TryGetValues(header, out IEnumerable<string> _);
-
-            Assert.False(headerExists);
-        }
-
-        [Fact]
-        public async Task CorrelationIdHeaderFieldName_MatchesHeaderOption()
-        {
-            const string customHeader = "X-Test-RequestHeader";
-
-            var builder = new WebHostBuilder()
-               .Configure(app => app.UseCorrelationId())
-               .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.ResponseHeader = customHeader));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var header = response.Headers.GetValues(customHeader);
-
-            Assert.NotNull(header);
-        }
-
-        [Fact]
-        public async Task CorrelationId_SetToCorrelationIdFromRequestHeader()
-        {
-            var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
-            const string expectedHeaderValue = "123456";
-
-            var builder = new WebHostBuilder()
-               .Configure(app => app.UseCorrelationId())
-               .ConfigureServices(sc => sc.AddDefaultCorrelationId());
-
-            using var server = new TestServer(builder);
-
-            var request = new HttpRequestMessage();
-            request.Headers.Add(expectedHeaderName, expectedHeaderValue);
-
-            var response = await server.CreateClient().SendAsync(request);
-
-            var header = response.Headers.GetValues(expectedHeaderName);
-
-            Assert.Single(header, expectedHeaderValue);
-        }
-
-        [Fact]
-        public async Task CorrelationId_SetToGuid_RegisteredWithAddDefaultCorrelationId()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId());
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
-
-            var isGuid = Guid.TryParse(header.FirstOrDefault(), out _);
-
-            Assert.True(isGuid);
-        }
-
-        [Fact]
-        public async Task CorrelationId_SetToCustomGenerator_WhenCorrelationIdGeneratorIsSet()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.CorrelationIdGenerator = () => "Foo"));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
-
-            var correlationId = header.FirstOrDefault();
-
-            Assert.Equal("Foo", correlationId);
-        }
-
-        [Fact]
-        public async Task CorrelationId_NotSetToGuid_WhenUsingTheTraceIdentifierProvider()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddCorrelationId().WithTraceIdentifierProvider());
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
-
-            var isGuid = Guid.TryParse(header.FirstOrDefault(), out _);
-
-            Assert.False(isGuid);
-        }
-
-        [Fact]
-        public async Task CorrelationId_SetUsingCustomProvider_WhenCustomProviderIsRegistered()
-        {
-            var builder = new WebHostBuilder()
-                .Configure(app => app.UseCorrelationId())
-                .ConfigureServices(sc => sc.AddCorrelationId().WithCustomProvider<TestCorrelationIdProvider>());
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
-
-            Assert.Equal(TestCorrelationIdProvider.FixedCorrelationId, header.FirstOrDefault());
-        }
-
-        [Fact]
-        public async Task CorrelationId_ReturnedCorrectlyFromSingletonService()
-        {
-            var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.UseCorrelationId();
-                    app.Run(async rd =>
-                    {
-                        var singleton = app.ApplicationServices.GetService(typeof(SingletonClass)) as SingletonClass;
-                        var scoped = app.ApplicationServices.GetService(typeof(ScopedClass)) as ScopedClass;
-
-                        var data = Encoding.UTF8.GetBytes(singleton?.GetCorrelationFromScoped + "|" + scoped?.GetCorrelationFromScoped);
-
-                        await rd.Response.Body.WriteAsync(data, 0, data.Length);
-                    });
-                })
-                .ConfigureServices(sc =>
-                {
-                    sc.AddDefaultCorrelationId();
-                    sc.TryAddSingleton<SingletonClass>();
-                    sc.TryAddScoped<ScopedClass>();
+                        exception = e;
+                    }
                 });
 
-            using var server = new TestServer(builder);
+                app.UseCorrelationId();
+            })
+            .ConfigureServices(sc => sc.AddCorrelationId());
 
-            // compare that first request matches the header and the scoped value
-            var request = new HttpRequestMessage();
+        using var server = new TestServer(builder);
 
-            var response = await server.CreateClient().SendAsync(request);
+        await server.CreateClient().GetAsync("");
 
-            var header = response.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+        Assert.NotNull(exception);
+        Assert.Equal(typeof(InvalidOperationException), exception.GetType());
+    }
 
-            var content = await response.Content.ReadAsStringAsync();
-            var splitContent = content.Split('|');
+    [Fact]
+    public async Task DoesNotThrow_WhenCorrelationIdProviderIsRegistered()
+    {
+        Exception exception = null;
 
-            Assert.Equal(header, splitContent[0]);
-            Assert.Equal(splitContent[0], splitContent[1]);
-
-            // compare that second request matches the header and the scoped value
-            var request2 = new HttpRequestMessage();
-
-            var response2 = await server.CreateClient().SendAsync(request2);
-
-            var header2 = response2.Headers.GetValues(expectedHeaderName).FirstOrDefault();
-
-            var content2 = await response2.Content.ReadAsStringAsync();
-            var splitContent2 = content2.Split('|');
-
-            Assert.Equal(header2, splitContent2[0]);
-            Assert.Equal(splitContent2[0], splitContent2[1]);
-        }
-
-        [Fact]
-        public async Task CorrelationId_ReturnedCorrectlyFromTransientService()
-        {
-            var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use(async (ctx, next) =>
                 {
-                    app.UseCorrelationId();
-                    app.Run(async rd =>
+                    try
                     {
-                        var transient = app.ApplicationServices.GetService(typeof(TransientClass)) as TransientClass;
-                        var scoped = app.ApplicationServices.GetService(typeof(ScopedClass)) as ScopedClass;
-
-                        var data = Encoding.UTF8.GetBytes(transient?.GetCorrelationFromScoped + "|" + scoped?.GetCorrelationFromScoped);
-
-                        await rd.Response.Body.WriteAsync(data, 0, data.Length);
-                    });
-                })
-                .ConfigureServices(sc =>
-                {
-                    sc.AddDefaultCorrelationId();
-                    sc.TryAddTransient<TransientClass>();
-                    sc.TryAddScoped<ScopedClass>();
+                        await next.Invoke();
+                    }
+                    catch (Exception e)
+                    {
+                        exception = e;
+                    }
                 });
 
-            using var server = new TestServer(builder);
+                app.UseCorrelationId();
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId());
 
-            // compare that first request matches the header and the scoped value
-            var request = new HttpRequestMessage();
+        using var server = new TestServer(builder);
 
-            var response = await server.CreateClient().SendAsync(request);
+        await server.CreateClient().GetAsync("");
 
-            var header = response.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+        Assert.Null(exception);
+    }
 
-            var content = await response.Content.ReadAsStringAsync();
-            var splitContent = content.Split('|');
+    [Fact]
+    public async Task ReturnsBadRequest_WhenEnforceOptionSetToTrue_AndNoExistingHeaderIsSent()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.EnforceHeader = true));
 
-            Assert.Equal(header, splitContent[0]);
-            Assert.Equal(splitContent[0], splitContent[1]);
+        using var server = new TestServer(builder);
 
-            // compare that second request matches the header and the scoped value
-            var request2 = new HttpRequestMessage();
+        var response = await server.CreateClient().GetAsync("");
 
-            var response2 = await server.CreateClient().SendAsync(request2);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 
-            var header2 = response2.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+    [Fact]
+    public async Task DoesNotReturnBadRequest_WhenEnforceOptionSetToFalse_AndNoExistingHeaderIsSent()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.EnforceHeader = false));
 
-            var content2 = await response2.Content.ReadAsStringAsync();
-            var splitContent2 = content2.Split('|');
+        using var server = new TestServer(builder);
 
-            Assert.Equal(header2, splitContent2[0]);
-            Assert.Equal(splitContent2[0], splitContent2[1]);
-        }
+        var response = await server.CreateClient().GetAsync("");
 
-        [Fact]
-        public async Task CorrelationContextIncludesHeaderValue_WhichMatchesTheOriginalOptionsValue()
-        {
-            const string customHeader = "custom-header";
+        Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.UseCorrelationId();
-
-                    app.Use(async (ctx, next) =>
-                    {
-                        await next.Invoke();
-                        var accessor = ctx.RequestServices.GetRequiredService<ICorrelationContextAccessor>();
-                        ctx.Response.StatusCode = StatusCodes.Status200OK;
-                        await ctx.Response.WriteAsync(accessor.CorrelationContext.Header);
-                    });
-                })
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.RequestHeader = customHeader));
-
-            using var server = new TestServer(builder);
-
-            var response = await server.CreateClient().GetAsync("");
-
-            var body = await response.Content.ReadAsStringAsync();
-
-            Assert.Equal(body, customHeader);
-        }
-
-        [Fact]
-        public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsFalse()
-        {
-            string originalTraceIdentifier = null;
-            string traceIdentifier = null;
-
-            const string correlationId = "123456";
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Use(async (ctx, next) =>
-                    {
-                        originalTraceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                    });
-
-                    app.UseCorrelationId();
-
-                    app.Use(async (ctx, next) =>
-                    {
-                        traceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                        await Task.CompletedTask;
-                    });
-                })
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.UpdateTraceIdentifier = false));
-
-            using var server = new TestServer(builder);
-
-            var request = new HttpRequestMessage();
-            request.Headers.Add(CorrelationIdOptions.DefaultHeader, correlationId);
-
-            await server.CreateClient().SendAsync(request);
-
-            Assert.Equal(originalTraceIdentifier, traceIdentifier);
-        }
-
-        [Fact]
-        public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsTrue_ButIncomingCorrelationIdIsEmpty()
-        {
-            string originalTraceIdentifier = null;
-            string traceIdentifier = null;
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Use(async (ctx, next) =>
-                    {
-                        originalTraceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                    });
-
-                    app.UseCorrelationId();
-
-                    app.Use(async (ctx, next) =>
-                    {
-                        traceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                        await Task.CompletedTask;
-                    });
-                })
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.UpdateTraceIdentifier = true));
-
-            using var server = new TestServer(builder);
-
-            var request = new HttpRequestMessage();
-            request.Headers.Add(CorrelationIdOptions.DefaultHeader, "");
-
-            await server.CreateClient().SendAsync(request);
-
-            Assert.NotEqual(originalTraceIdentifier, traceIdentifier);
-        }
-
-        [Fact]
-        public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsTrue_AndGeneratedCorrelationIdIsNull()
-        {
-            string originalTraceIdentifier = null;
-            string traceIdentifier = null;
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.Use(async (ctx, next) =>
-                    {
-                        originalTraceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                    });
-
-                    app.UseCorrelationId();
-
-                    app.Use(async (ctx, next) =>
-                    {
-                        traceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                        await Task.CompletedTask;
-                    });
-                })
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => { options.UpdateTraceIdentifier = true; options.CorrelationIdGenerator = () => null; }));
-
-            using var server = new TestServer(builder);
-
-            await server.CreateClient().GetAsync("");
-
-            Assert.Equal(originalTraceIdentifier, traceIdentifier);
-        }
-
-        [Fact]
-        public async Task TraceIdentifier_IsUpdated_WhenUpdateTraceIdentifierIsTrue()
-        {
-            string traceIdentifier = null;
-
-            var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
-            const string correlationId = "123456";
-
-            var builder = new WebHostBuilder()
-                .Configure(app =>
-                {
-                    app.UseCorrelationId();
-
-                    app.Use(async (ctx, next) =>
-                    {
-                        traceIdentifier = ctx.TraceIdentifier;
-                        await next.Invoke();
-                        await Task.CompletedTask;
-                    });
-                })
-                .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.UpdateTraceIdentifier = true));
-
-            using var server = new TestServer(builder);
-
-            var request = new HttpRequestMessage();
-            request.Headers.Add(expectedHeaderName, correlationId);
-
-            await server.CreateClient().SendAsync(request);
-
-            Assert.Equal(correlationId, traceIdentifier);
-        }
-
-        private class SingletonClass
-        {
-            private readonly ICorrelationContextAccessor _correlationContext;
-
-            public SingletonClass(ICorrelationContextAccessor correlationContext)
+    [Fact]
+    public async Task IgnoresRequestHeader_WhenOptionIsTrue()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options =>
             {
-                _correlationContext = correlationContext;
-            }
+                options.IgnoreRequestHeader = true;
+                options.IncludeInResponse = true;
+            }));
+        ;
 
-            public string GetCorrelationFromScoped => _correlationContext.CorrelationContext.CorrelationId;
-        }
+        using var server = new TestServer(builder);
 
-        private class ScopedClass
-        {
-            private readonly ICorrelationContextAccessor _correlationContext;
+        var request = new HttpRequestMessage();
+        request.Headers.Add(CorrelationIdOptions.DefaultHeader, "ABC123");
 
-            public ScopedClass(ICorrelationContextAccessor correlationContext)
+        var response = await server.CreateClient().SendAsync(request);
+
+        var header = response.Headers.GetValues(CorrelationIdOptions.DefaultHeader).FirstOrDefault();
+
+        Assert.NotEqual("ABC123", header);
+    }
+
+    [Fact]
+    public async Task DoesNotIgnoresRequestHeader_WhenOptionIsFalse()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options =>
             {
-                _correlationContext = correlationContext;
-            }
+                options.IgnoreRequestHeader = false;
+                options.IncludeInResponse = true;
+            }));
+        ;
 
-            public string GetCorrelationFromScoped => _correlationContext.CorrelationContext.CorrelationId;
-        }
+        using var server = new TestServer(builder);
 
-        private class TransientClass
-        {
-            private readonly ICorrelationContextAccessor _correlationContext;
+        var request = new HttpRequestMessage();
+        request.Headers.Add(CorrelationIdOptions.DefaultHeader, "ABC123");
 
-            public TransientClass(ICorrelationContextAccessor correlationContext)
+        var response = await server.CreateClient().SendAsync(request);
+
+        var header = response.Headers.GetValues(CorrelationIdOptions.DefaultHeader).FirstOrDefault();
+
+        Assert.Equal("ABC123", header);
+    }
+
+    [Fact]
+    public async Task ReturnsCorrelationIdInResponseHeader_WhenOptionSetToTrue()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.IncludeInResponse = true));
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var header = response.Headers.GetValues(CorrelationIdOptions.DefaultHeader);
+
+        Assert.NotNull(header);
+    }
+
+    [Fact]
+    public async Task DoesNotThrowException_WhenOptionSetToTrue_IfHeaderIsAlreadySet()
+    {
+        Exception exception = null;
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
             {
-                _correlationContext = correlationContext;
-            }
+                app.Use(async (ctx, next) =>
+                {
+                    try
+                    {
+                        await next.Invoke();
+                    }
+                    catch (Exception e)
+                    {
+                        exception = e;
+                    }
+                });
 
-            public string GetCorrelationFromScoped => _correlationContext.CorrelationContext.CorrelationId;
-        }
+                app.UseCorrelationId();
+                app.UseCorrelationId(); // header will already be set on this second use of the middleware
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId());
 
-        private class TestCorrelationIdProvider : ICorrelationIdProvider
+        using var server = new TestServer(builder);
+
+        await server.CreateClient().GetAsync("");
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task DoesNotReturnCorrelationIdInResponseHeader_WhenIncludeInResponseIsFalse()
+    {
+        string header = null;
+
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options =>
+            {
+                options.IncludeInResponse = false;
+                header = options.RequestHeader;
+            }));
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var headerExists = response.Headers.TryGetValues(header, out var _);
+
+        Assert.False(headerExists);
+    }
+
+    [Fact]
+    public async Task CorrelationIdHeaderFieldName_MatchesHeaderOption()
+    {
+        const string customHeader = "X-Test-RequestHeader";
+
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.ResponseHeader = customHeader));
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var header = response.Headers.GetValues(customHeader);
+
+        Assert.NotNull(header);
+    }
+
+    [Fact]
+    public async Task CorrelationId_SetToCorrelationIdFromRequestHeader()
+    {
+        var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
+        const string expectedHeaderValue = "123456";
+
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId());
+
+        using var server = new TestServer(builder);
+
+        var request = new HttpRequestMessage();
+        request.Headers.Add(expectedHeaderName, expectedHeaderValue);
+
+        var response = await server.CreateClient().SendAsync(request);
+
+        var header = response.Headers.GetValues(expectedHeaderName);
+
+        Assert.Single(header, expectedHeaderValue);
+    }
+
+    [Fact]
+    public async Task CorrelationId_SetToGuid_RegisteredWithAddDefaultCorrelationId()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId());
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
+
+        var isGuid = Guid.TryParse(header.FirstOrDefault(), out _);
+
+        Assert.True(isGuid);
+    }
+
+    [Fact]
+    public async Task CorrelationId_SetToCustomGenerator_WhenCorrelationIdGeneratorIsSet()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(
+                sc => sc.AddDefaultCorrelationId(options => options.CorrelationIdGenerator = () => "Foo"));
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
+
+        var correlationId = header.FirstOrDefault();
+
+        Assert.Equal("Foo", correlationId);
+    }
+
+    [Fact]
+    public async Task CorrelationId_NotSetToGuid_WhenUsingTheTraceIdentifierProvider()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddCorrelationId().WithTraceIdentifierProvider());
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
+
+        var isGuid = Guid.TryParse(header.FirstOrDefault(), out _);
+
+        Assert.False(isGuid);
+    }
+
+    [Fact]
+    public async Task CorrelationId_SetUsingCustomProvider_WhenCustomProviderIsRegistered()
+    {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.UseCorrelationId())
+            .ConfigureServices(sc => sc.AddCorrelationId().WithCustomProvider<TestCorrelationIdProvider>());
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var header = response.Headers.GetValues(new CorrelationIdOptions().RequestHeader);
+
+        Assert.Equal(TestCorrelationIdProvider.FixedCorrelationId, header.FirstOrDefault());
+    }
+
+    [Fact]
+    public async Task CorrelationId_ReturnedCorrectlyFromSingletonService()
+    {
+        var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseCorrelationId();
+                app.Run(async rd =>
+                {
+                    var singleton = app.ApplicationServices.GetService(typeof(SingletonClass)) as SingletonClass;
+                    var scoped = app.ApplicationServices.GetService(typeof(ScopedClass)) as ScopedClass;
+
+                    var data = Encoding.UTF8.GetBytes(singleton?.GetCorrelationFromScoped + "|" +
+                                                      scoped?.GetCorrelationFromScoped);
+
+                    await rd.Response.Body.WriteAsync(data, 0, data.Length);
+                });
+            })
+            .ConfigureServices(sc =>
+            {
+                sc.AddDefaultCorrelationId();
+                sc.TryAddSingleton<SingletonClass>();
+                sc.TryAddScoped<ScopedClass>();
+            });
+
+        using var server = new TestServer(builder);
+
+        // compare that first request matches the header and the scoped value
+        var request = new HttpRequestMessage();
+
+        var response = await server.CreateClient().SendAsync(request);
+
+        var header = response.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var splitContent = content.Split('|');
+
+        Assert.Equal(header, splitContent[0]);
+        Assert.Equal(splitContent[0], splitContent[1]);
+
+        // compare that second request matches the header and the scoped value
+        var request2 = new HttpRequestMessage();
+
+        var response2 = await server.CreateClient().SendAsync(request2);
+
+        var header2 = response2.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+
+        var content2 = await response2.Content.ReadAsStringAsync();
+        var splitContent2 = content2.Split('|');
+
+        Assert.Equal(header2, splitContent2[0]);
+        Assert.Equal(splitContent2[0], splitContent2[1]);
+    }
+
+    [Fact]
+    public async Task CorrelationId_ReturnedCorrectlyFromTransientService()
+    {
+        var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseCorrelationId();
+                app.Run(async rd =>
+                {
+                    var transient = app.ApplicationServices.GetService(typeof(TransientClass)) as TransientClass;
+                    var scoped = app.ApplicationServices.GetService(typeof(ScopedClass)) as ScopedClass;
+
+                    var data = Encoding.UTF8.GetBytes(transient?.GetCorrelationFromScoped + "|" +
+                                                      scoped?.GetCorrelationFromScoped);
+
+                    await rd.Response.Body.WriteAsync(data, 0, data.Length);
+                });
+            })
+            .ConfigureServices(sc =>
+            {
+                sc.AddDefaultCorrelationId();
+                sc.TryAddTransient<TransientClass>();
+                sc.TryAddScoped<ScopedClass>();
+            });
+
+        using var server = new TestServer(builder);
+
+        // compare that first request matches the header and the scoped value
+        var request = new HttpRequestMessage();
+
+        var response = await server.CreateClient().SendAsync(request);
+
+        var header = response.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var splitContent = content.Split('|');
+
+        Assert.Equal(header, splitContent[0]);
+        Assert.Equal(splitContent[0], splitContent[1]);
+
+        // compare that second request matches the header and the scoped value
+        var request2 = new HttpRequestMessage();
+
+        var response2 = await server.CreateClient().SendAsync(request2);
+
+        var header2 = response2.Headers.GetValues(expectedHeaderName).FirstOrDefault();
+
+        var content2 = await response2.Content.ReadAsStringAsync();
+        var splitContent2 = content2.Split('|');
+
+        Assert.Equal(header2, splitContent2[0]);
+        Assert.Equal(splitContent2[0], splitContent2[1]);
+    }
+
+    [Fact]
+    public async Task CorrelationContextIncludesHeaderValue_WhichMatchesTheOriginalOptionsValue()
+    {
+        const string customHeader = "custom-header";
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseCorrelationId();
+
+                app.Use(async (ctx, next) =>
+                {
+                    await next.Invoke();
+                    var accessor = ctx.RequestServices.GetRequiredService<ICorrelationContextAccessor>();
+                    ctx.Response.StatusCode = StatusCodes.Status200OK;
+                    await ctx.Response.WriteAsync(accessor.CorrelationContext.Header);
+                });
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.RequestHeader = customHeader));
+
+        using var server = new TestServer(builder);
+
+        var response = await server.CreateClient().GetAsync("");
+
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(body, customHeader);
+    }
+
+    [Fact]
+    public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsFalse()
+    {
+        string originalTraceIdentifier = null;
+        string traceIdentifier = null;
+
+        const string correlationId = "123456";
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use(async (ctx, next) =>
+                {
+                    originalTraceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                });
+
+                app.UseCorrelationId();
+
+                app.Use(async (ctx, next) =>
+                {
+                    traceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                    await Task.CompletedTask;
+                });
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.UpdateTraceIdentifier = false));
+
+        using var server = new TestServer(builder);
+
+        var request = new HttpRequestMessage();
+        request.Headers.Add(CorrelationIdOptions.DefaultHeader, correlationId);
+
+        await server.CreateClient().SendAsync(request);
+
+        Assert.Equal(originalTraceIdentifier, traceIdentifier);
+    }
+
+    [Fact]
+    public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsTrue_ButIncomingCorrelationIdIsEmpty()
+    {
+        string originalTraceIdentifier = null;
+        string traceIdentifier = null;
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use(async (ctx, next) =>
+                {
+                    originalTraceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                });
+
+                app.UseCorrelationId();
+
+                app.Use(async (ctx, next) =>
+                {
+                    traceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                    await Task.CompletedTask;
+                });
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.UpdateTraceIdentifier = true));
+
+        using var server = new TestServer(builder);
+
+        var request = new HttpRequestMessage();
+        request.Headers.Add(CorrelationIdOptions.DefaultHeader, "");
+
+        await server.CreateClient().SendAsync(request);
+
+        Assert.NotEqual(originalTraceIdentifier, traceIdentifier);
+    }
+
+    [Fact]
+    public async Task TraceIdentifier_IsNotUpdated_WhenUpdateTraceIdentifierIsTrue_AndGeneratedCorrelationIdIsNull()
+    {
+        string originalTraceIdentifier = null;
+        string traceIdentifier = null;
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use(async (ctx, next) =>
+                {
+                    originalTraceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                });
+
+                app.UseCorrelationId();
+
+                app.Use(async (ctx, next) =>
+                {
+                    traceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                    await Task.CompletedTask;
+                });
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options =>
+            {
+                options.UpdateTraceIdentifier = true;
+                options.CorrelationIdGenerator = () => null;
+            }));
+
+        using var server = new TestServer(builder);
+
+        await server.CreateClient().GetAsync("");
+
+        Assert.Equal(originalTraceIdentifier, traceIdentifier);
+    }
+
+    [Fact]
+    public async Task TraceIdentifier_IsUpdated_WhenUpdateTraceIdentifierIsTrue()
+    {
+        string traceIdentifier = null;
+
+        var expectedHeaderName = new CorrelationIdOptions().RequestHeader;
+        const string correlationId = "123456";
+
+        var builder = new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.UseCorrelationId();
+
+                app.Use(async (ctx, next) =>
+                {
+                    traceIdentifier = ctx.TraceIdentifier;
+                    await next.Invoke();
+                    await Task.CompletedTask;
+                });
+            })
+            .ConfigureServices(sc => sc.AddDefaultCorrelationId(options => options.UpdateTraceIdentifier = true));
+
+        using var server = new TestServer(builder);
+
+        var request = new HttpRequestMessage();
+        request.Headers.Add(expectedHeaderName, correlationId);
+
+        await server.CreateClient().SendAsync(request);
+
+        Assert.Equal(correlationId, traceIdentifier);
+    }
+
+    private class SingletonClass
+    {
+        private readonly ICorrelationContextAccessor _correlationContext;
+
+        public SingletonClass(ICorrelationContextAccessor correlationContext)
         {
-            public const string FixedCorrelationId = "TestCorrelationId";
-
-            public string GenerateCorrelationId(HttpContext httpContext) => FixedCorrelationId;
+            _correlationContext = correlationContext;
         }
 
+        public string GetCorrelationFromScoped => _correlationContext.CorrelationContext.CorrelationId;
+    }
+
+    private class ScopedClass
+    {
+        private readonly ICorrelationContextAccessor _correlationContext;
+
+        public ScopedClass(ICorrelationContextAccessor correlationContext)
+        {
+            _correlationContext = correlationContext;
+        }
+
+        public string GetCorrelationFromScoped => _correlationContext.CorrelationContext.CorrelationId;
+    }
+
+    private class TransientClass
+    {
+        private readonly ICorrelationContextAccessor _correlationContext;
+
+        public TransientClass(ICorrelationContextAccessor correlationContext)
+        {
+            _correlationContext = correlationContext;
+        }
+
+        public string GetCorrelationFromScoped => _correlationContext.CorrelationContext.CorrelationId;
+    }
+
+    private class TestCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public const string FixedCorrelationId = "TestCorrelationId";
+
+        public string GenerateCorrelationId()
+        {
+            return FixedCorrelationId;
+        }
     }
 }


### PR DESCRIPTION
- .NET 6.0 Upgrade
- Added a new option to set log level severity when a correlation ID is found in the header or a correlation ID is missing from the header.
- Sample has been updated
- All tests are passing