### PR TITLE
Removing Non-Concept HttpContext Dependency

### DIFF
--- a/samples/3.1/MvcSample/DoNothingCorrelationIdProvider.cs
+++ b/samples/3.1/MvcSample/DoNothingCorrelationIdProvider.cs
@@ -1,11 +1,10 @@
 using CorrelationId.Abstractions;
-using Microsoft.AspNetCore.Http;
 
 namespace MvcSample
 {
     public class DoNothingCorrelationIdProvider : ICorrelationIdProvider
     {
-        public string GenerateCorrelationId(HttpContext context)
+        public string GenerateCorrelationId()
         {
             return null;
         }

--- a/src/CorrelationId/Abstractions/ICorrelationIdProvider.cs
+++ b/src/CorrelationId/Abstractions/ICorrelationIdProvider.cs
@@ -10,8 +10,7 @@ namespace CorrelationId.Abstractions
         /// <summary>
         /// Generates a correlation ID string for the current request.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> of the current request.</param>
         /// <returns>A string representing the correlation ID.</returns>
-        string GenerateCorrelationId(HttpContext context);
+        string GenerateCorrelationId();
     }
 }

--- a/src/CorrelationId/CorrelationId.csproj
+++ b/src/CorrelationId/CorrelationId.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+	<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />

--- a/src/CorrelationId/CorrelationIdMiddleware.cs
+++ b/src/CorrelationId/CorrelationIdMiddleware.cs
@@ -80,7 +80,7 @@ namespace CorrelationId
 
             if (_options.IgnoreRequestHeader || RequiresGenerationOfCorrelationId(hasCorrelationIdHeader, cid))
             {
-                correlationId = GenerateCorrelationId(context);
+                correlationId = GenerateCorrelationId();
             }
 
             if (!string.IsNullOrEmpty(correlationId) && _options.UpdateTraceIdentifier)
@@ -132,7 +132,7 @@ namespace CorrelationId
         private static bool RequiresGenerationOfCorrelationId(bool idInHeader, StringValues idFromHeader) =>
             !idInHeader || StringValues.IsNullOrEmpty(idFromHeader);
 
-        private string GenerateCorrelationId(HttpContext ctx)
+        private string GenerateCorrelationId()
         {
             string correlationId;
 
@@ -143,7 +143,7 @@ namespace CorrelationId
                 return correlationId;
             }
 
-            correlationId = _correlationIdProvider.GenerateCorrelationId(ctx);
+            correlationId = _correlationIdProvider.GenerateCorrelationId();
             Log.GeneratedHeaderUsingProvider(_logger, correlationId, _correlationIdProvider.GetType());
             return correlationId;
         }

--- a/src/CorrelationId/DependencyInjection/CorrelationIdBuilderExtensions.cs
+++ b/src/CorrelationId/DependencyInjection/CorrelationIdBuilderExtensions.cs
@@ -3,6 +3,7 @@ using CorrelationId.Providers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 
 namespace CorrelationId.DependencyInjection
 {
@@ -74,6 +75,7 @@ namespace CorrelationId.DependencyInjection
                 throw new InvalidOperationException("A provider has already been added.");
             }
 
+            builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             builder.Services.TryAddSingleton<ICorrelationIdProvider, TraceIdCorrelationIdProvider>();
 
             return builder;

--- a/src/CorrelationId/Providers/GuidCorrelationIdProvider.cs
+++ b/src/CorrelationId/Providers/GuidCorrelationIdProvider.cs
@@ -10,6 +10,6 @@ namespace CorrelationId.Providers
     public class GuidCorrelationIdProvider : ICorrelationIdProvider
     {
         /// <inheritdoc />
-        public string GenerateCorrelationId(HttpContext ctx) => Guid.NewGuid().ToString();
+        public string GenerateCorrelationId() => Guid.NewGuid().ToString();
     }
 }

--- a/src/CorrelationId/Providers/TraceIdCorrelationIdProvider.cs
+++ b/src/CorrelationId/Providers/TraceIdCorrelationIdProvider.cs
@@ -8,7 +8,14 @@ namespace CorrelationId.Providers
     /// </summary>
     public class TraceIdCorrelationIdProvider : ICorrelationIdProvider
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public TraceIdCorrelationIdProvider(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
         /// <inheritdoc />
-        public string GenerateCorrelationId(HttpContext ctx) => ctx.TraceIdentifier;
+        public string GenerateCorrelationId() => _httpContextAccessor.HttpContext.TraceIdentifier;
     }
 }

--- a/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
+++ b/test/CorrelationId.Tests/CorrelationIdMiddlewareTests.cs
@@ -641,7 +641,7 @@ namespace CorrelationId.Tests
         {
             public const string FixedCorrelationId = "TestCorrelationId";
 
-            public string GenerateCorrelationId(HttpContext context) => FixedCorrelationId;
+            public string GenerateCorrelationId() => FixedCorrelationId;
         }
 
     }


### PR DESCRIPTION
HttpContext dependency removed from CorrelationIdProviders, IHttpContextAccessor dependency added to TraceIdentifierCorrelationIdProvider.